### PR TITLE
Harden PRAGMA table/foreign-key introspection + typed FK lookup for ER diagram

### DIFF
--- a/src/databaseEditorProvider.ts
+++ b/src/databaseEditorProvider.ts
@@ -871,13 +871,13 @@ export class DatabaseEditorProvider implements vscode.CustomReadonlyEditorProvid
                     try {
                         this.debugLog('ERDiagram', `Checking foreign keys for table ${index + 1}/${tables.length}: ${table.name}`);
                         
-                        const foreignKeys = await dbService.executeQuery(`PRAGMA foreign_key_list(${table.name})`);
-                        this.debugLog('ERDiagram', `Foreign keys result for ${table.name}:`, foreignKeys);
+                        const foreignKeys = await dbService.getForeignKeys(table.name);
+                        this.debugLog('ERDiagram', `Foreign keys for ${table.name}:`, foreignKeys);
                         
-                        const fkList = foreignKeys.values.map((fk: any) => ({
-                            column: fk[3], // from column
-                            referencedTable: fk[2], // to table
-                            referencedColumn: fk[4] // to column
+                        const fkList = foreignKeys.map((fk) => ({
+                            column: fk.column,
+                            referencedTable: fk.referencedTable,
+                            referencedColumn: fk.referencedColumn
                         }));
                         
                         if (fkList.length > 0) {

--- a/src/databaseService.ts
+++ b/src/databaseService.ts
@@ -78,6 +78,10 @@ export class DatabaseService {
         }
     }
 
+    private quoteIdentifier(identifier: string): string {
+        return `"${identifier.replace(/"/g, '""')}"`;
+    }
+
     async initialize(): Promise<void> {
         if (!this.SQL) {
             this.SQL = await initSqlJs({
@@ -271,7 +275,7 @@ export class DatabaseService {
             throw new Error('Database not opened');
         }
 
-        const stmt = this.db.prepare(`PRAGMA table_info(${tableName})`);
+        const stmt = this.db.prepare(`PRAGMA table_info(${this.quoteIdentifier(tableName)})`);
         const columns: ColumnInfo[] = [];
         
         while (stmt.step()) {
@@ -623,7 +627,7 @@ export class DatabaseService {
 
         // Use executeQuery instead of direct prepared statements to ensure
         // compatibility with SQLCipher encrypted databases
-        const query = `PRAGMA table_info(${tableName})`;
+        const query = `PRAGMA table_info(${this.quoteIdentifier(tableName)})`;
         const result = await this.executeQuery(query);
         
         return result;
@@ -634,7 +638,7 @@ export class DatabaseService {
             throw new Error('Database not opened');
         }
 
-        const stmt = this.db.prepare(`PRAGMA foreign_key_list(${tableName})`);
+        const stmt = this.db.prepare(`PRAGMA foreign_key_list(${this.quoteIdentifier(tableName)})`);
         const foreignKeys: ForeignKeyInfo[] = [];
         
         while (stmt.step()) {


### PR DESCRIPTION
### Summary

This PR improves how we introspect SQLite schema metadata by:

* Switching ER diagram FK discovery to a typed `dbService.getForeignKeys(tableName)` API (instead of parsing raw `executeQuery` results).
* Safely quoting table identifiers when building PRAGMA statements to support edge-case table names and reduce injection/parse issues.

### Changes

#### ✅ ER diagram: use typed FK results

* Replaced:

  * `executeQuery(\`PRAGMA foreign_key_list(${table.name})`)`+`foreignKeys.values[...]` indexing
* With:

  * `dbService.getForeignKeys(table.name)` returning a typed array
  * Mapping uses explicit properties: `fk.column`, `fk.referencedTable`, `fk.referencedColumn`
* Debug logging updated to match the new data shape and be more readable.

#### 🔒 DatabaseService: quote identifiers in PRAGMA calls

* Added `quoteIdentifier(identifier: string)`:

  * Wraps identifiers in double quotes
  * Escapes embedded quotes (`"` → `""`)
* Updated PRAGMA usages to quote `tableName`:

  * `PRAGMA table_info(...)` (both direct prepare + SQLCipher-safe executeQuery path)
  * `PRAGMA foreign_key_list(...)`

### Why

* **Correctness**: Table names with spaces, reserved keywords, hyphens, or quotes can break PRAGMA calls when interpolated raw.
* **Safety**: Although inputs come from schema enumeration, quoting identifiers prevents accidental SQL parsing issues and guards against unsafe interpolation patterns.
* **Maintainability**: The ER diagram code no longer relies on magic array indexes (`fk[3]`, `fk[2]`, `fk[4]`) and the `executeQuery` return shape.


Solves this issue: https://github.com/Bowlerr/sqlite-intelliview-vscode/issues/8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved database identifier handling with safer escaping for table names and schema operations.
  * Refactored foreign key retrieval logic for better maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->