### PR TITLE
feat: support additional SQLite file extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,13 +6,37 @@ node_modules
 
 # Test databases and files
 test*.db
+test*.db3
+test*.s3db
+test*.sl3
 test*.sqlite
+test*.sqlite3
 test*.sqlite-shm
 test*.sqlite-wal
+test*.sqlite3-shm
+test*.sqlite3-wal
+test*.db3-shm
+test*.db3-wal
+test*.s3db-shm
+test*.s3db-wal
+test*.sl3-shm
+test*.sl3-wal
 example*.db
+example*.db3
+example*.s3db
+example*.sl3
 example*.sqlite
+example*.sqlite3
 example*.sqlite-shm
 example*.sqlite-wal
+example*.sqlite3-shm
+example*.sqlite3-wal
+example*.db3-shm
+example*.db3-wal
+example*.s3db-shm
+example*.s3db-wal
+example*.sl3-shm
+example*.sl3-wal
 *.sql
 test_*.js
 generate_*.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## Unreleased
+
+### Added
+
+- Built-in recognition for `.db3`, `.s3db`, and `.sl3` databases, with case-insensitive matching for all supported SQLite extensions.
+- `sqliteIntelliView.additionalFileExtensions` for recognizing custom SQLite filename extensions in commands and file pickers.
+
 ## [0.4.9] - 2026-04-27
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ A quick tour of the main workflows (all offline, inside VS Code):
 
 - **Free**: no paywalls; MIT-licensed.
 - **Offline + secure by design**: database contents stay on your machine (the extension doesn’t make network requests).
-- **Custom database editor** for `.db`, `.sqlite`, `.sqlite3` (opens as a rich UI, not plain text).
+- **Custom database editor** for `.sqlite`, `.sqlite3`, `.db`, `.db3`, `.s3db`, and `.sl3` (opens as a rich UI, not plain text).
 - **Database Explorer view** (tables + columns) while a database is open.
 - **Multi-table tabs** (open multiple tables/results, drag to reorder).
 - **Fast table browsing**: pagination, quick search, sorting, column filters, resizable columns/rows, column pinning.
@@ -85,7 +85,7 @@ A quick tour of the main workflows (all offline, inside VS Code):
 
 ## Quick Start
 
-1. Open any `.db`, `.sqlite`, or `.sqlite3` file.
+1. Open any `.sqlite`, `.sqlite3`, `.db`, `.db3`, `.s3db`, or `.sl3` file.
 2. If VS Code asks, choose **Open With… → SQLite Database IntelliView**.
 3. Use the left **Database Explorer** to open tables, then:
    - **Data** tab: browse/edit rows
@@ -147,9 +147,22 @@ If the database is locked by another process (or you only have read-only access)
 
 For best results, ensure the `sqlite3` CLI is available on your `PATH` (used for WAL checkpointing on unencrypted databases).
 
-## Settings (WAL + Refresh)
+## Settings
 
-These VS Code settings control WAL behavior and external refresh noise:
+SQLite IntelliView recognizes `.sqlite`, `.sqlite3`, `.db`, `.db3`, `.s3db`, and `.sl3` files by default. Add other extensions with `sqliteIntelliView.additionalFileExtensions`. Values may include a leading dot, are matched case-insensitively, and invalid or duplicate entries are ignored:
+
+```json
+{
+  "sqliteIntelliView.additionalFileExtensions": [
+    ".database",
+    "sqlite-backup"
+  ]
+}
+```
+
+The additional extensions are available immediately in SQLite IntelliView's open dialogs and commands. VS Code custom editor associations, activation events, and Explorer context-menu visibility are static `package.json` contributions, so they cannot be changed dynamically from this setting. To open a custom-extension file, run **SQLite IntelliView: Open SQLite Database** and select it.
+
+These settings control WAL behavior and external refresh noise:
 
 - `sqliteIntelliView.walCheckpointMode` (`"full" | "passive" | "off"`, default: `"full"`): controls how WAL checkpointing runs when opening a database with a `-wal` file.
   - `full`: more aggressive checkpoint (best chance of up-to-date data).

--- a/package.json
+++ b/package.json
@@ -94,13 +94,22 @@
         "displayName": "SQLite Database IntelliView",
         "selector": [
           {
-            "filenamePattern": "*.db"
+            "filenamePattern": "*.[dD][bB]"
           },
           {
-            "filenamePattern": "*.sqlite"
+            "filenamePattern": "*.[dD][bB]3"
           },
           {
-            "filenamePattern": "*.sqlite3"
+            "filenamePattern": "*.[sS]3[dD][bB]"
+          },
+          {
+            "filenamePattern": "*.[sS][lL]3"
+          },
+          {
+            "filenamePattern": "*.[sS][qQ][lL][iI][tT][eE]"
+          },
+          {
+            "filenamePattern": "*.[sS][qQ][lL][iI][tT][eE]3"
           }
         ],
         "priority": "default"
@@ -120,7 +129,7 @@
       "explorer/context": [
         {
           "command": "sqlite-intelliview-vscode.openDatabase",
-          "when": "resourceExtname == .db || resourceExtname == .sqlite || resourceExtname == .sqlite3",
+          "when": "resourceExtname =~ /\\.(db3?|sqlite3?|s3db|sl3)$/i",
           "group": "1_open"
         }
       ],
@@ -159,6 +168,15 @@
     "configuration": {
       "title": "SQLite IntelliView",
       "properties": {
+        "sqliteIntelliView.additionalFileExtensions": {
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true,
+          "markdownDescription": "Additional filename extensions to recognize as SQLite databases. Values may include a leading dot and are matched case-insensitively, for example `.database` or `sqlite-backup`. Invalid and duplicate values are ignored."
+        },
         "sqliteIntelliView.defaultPageSize": {
           "type": "number",
           "default": 1000,
@@ -241,5 +259,6 @@
     "sortablejs": "^1.15.6",
     "sql.js": "^1.13.0",
     "sqlite3": "^5.1.7"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/databaseWatcher.ts
+++ b/src/databaseWatcher.ts
@@ -1,6 +1,5 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
-import * as fs from 'fs';
 import { getWalFilePaths } from './walUtils';
 
 /**
@@ -58,7 +57,7 @@ export class DatabaseWatcher {
         const filterEvent = (uri: vscode.Uri) => {
             if (uri.fsPath === filePath) {
                 // For main database file, check if it's an internal update
-                if (filePath.endsWith('.db') || filePath.endsWith('.sqlite') || filePath.endsWith('.sqlite3')) {
+                if (filePath === debounceKey) {
                     if (isInternalUpdate(filePath)) {
                         // Suppress this event, it was triggered by our own write
                         return;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,8 +3,50 @@
 import * as vscode from 'vscode';
 import { DatabaseEditorProvider } from './databaseEditorProvider';
 import { DatabaseExplorerProvider } from './databaseExplorerProvider';
+import { getSQLiteFileExtensions, isSQLiteFilePath } from './fileExtensions';
 
 let databaseExplorerProvider: DatabaseExplorerProvider;
+
+function getAdditionalFileExtensions(): unknown[] {
+	const configured = vscode.workspace
+		.getConfiguration('sqliteIntelliView')
+		.get<unknown>('additionalFileExtensions', []);
+	return Array.isArray(configured) ? configured : [];
+}
+
+function getDatabaseDialogFilters(): Record<string, string[]> {
+	return {
+		'SQLite Database': getSQLiteFileExtensions(getAdditionalFileExtensions()),
+		'All Files': ['*']
+	};
+}
+
+function getTabInputUri(input: unknown): vscode.Uri | undefined {
+	if (!input || typeof input !== 'object' || !('uri' in input)) {
+		return undefined;
+	}
+
+	const uri = input.uri;
+	return uri instanceof vscode.Uri ? uri : undefined;
+}
+
+function getActiveDatabaseUri(): vscode.Uri | undefined {
+	const additionalExtensions = getAdditionalFileExtensions();
+	const editorUri = vscode.window.activeTextEditor?.document.uri;
+	if (editorUri && isSQLiteFilePath(editorUri.fsPath, additionalExtensions)) {
+		return editorUri;
+	}
+
+	const input = vscode.window.tabGroups.activeTabGroup?.activeTab?.input;
+	const inputUri = getTabInputUri(input);
+	const isCustomDatabaseEditor = input instanceof vscode.TabInputCustom
+		&& input.viewType === DatabaseEditorProvider.viewType;
+	if (inputUri && (isCustomDatabaseEditor || isSQLiteFilePath(inputUri.fsPath, additionalExtensions))) {
+		return inputUri;
+	}
+
+	return undefined;
+}
 
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
@@ -34,10 +76,6 @@ export function activate(context: vscode.ExtensionContext) {
 
 	// Register commands
 	const openDatabaseCommand = vscode.commands.registerCommand('sqlite-intelliview-vscode.openDatabase', async (uri?: vscode.Uri) => {
-		const isDatabaseFile = (target: vscode.Uri) => {
-			return ['.db', '.sqlite', '.sqlite3'].some(ext => target.fsPath.toLowerCase().endsWith(ext));
-		};
-
 		let dbUri: vscode.Uri | undefined = uri;
 
 		if (!dbUri) {
@@ -45,10 +83,7 @@ export function activate(context: vscode.ExtensionContext) {
 				canSelectFiles: true,
 				canSelectFolders: false,
 				canSelectMany: false,
-				filters: {
-					'SQLite Database': ['db', 'sqlite', 'sqlite3'],
-					'All Files': ['*']
-				}
+				filters: getDatabaseDialogFilters()
 			});
 
 			if (!result || result.length === 0) {
@@ -58,12 +93,9 @@ export function activate(context: vscode.ExtensionContext) {
 			dbUri = result[0];
 		}
 
-		if (!isDatabaseFile(dbUri)) {
-			vscode.window.showWarningMessage('Selected file is not a recognized database file');
-			return;
-		}
-
 		// Open with our custom editor (opening as text will often succeed but won't use the SQLite UI).
+		// DatabaseService validates the SQLite header and attempts a query after opening, so
+		// explicit opens are not rejected only because their filename has an unknown extension.
 		await vscode.commands.executeCommand('vscode.openWith', dbUri, DatabaseEditorProvider.viewType);
 
 		// Populate the Database Explorer (best-effort; encrypted DBs will require a key).
@@ -83,43 +115,18 @@ export function activate(context: vscode.ExtensionContext) {
 
 		if (encryptionKey) {
 			const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
-			const isDatabaseFile = (target: vscode.Uri) => {
-				return ['.db', '.sqlite', '.sqlite3'].some(ext => target.fsPath.toLowerCase().endsWith(ext));
-			};
-			const getActiveDatabaseUri = (): vscode.Uri | undefined => {
-				const editorUri = vscode.window.activeTextEditor?.document.uri;
-				if (editorUri && isDatabaseFile(editorUri)) {
-					return editorUri;
-				}
-				const activeTab = vscode.window.tabGroups.activeTabGroup?.activeTab;
-				const input: any = activeTab?.input;
-				const inputUri: vscode.Uri | undefined = input && input.uri && typeof input.uri.fsPath === 'string' ? input.uri : undefined;
-				if (inputUri && isDatabaseFile(inputUri)) {
-					return inputUri;
-				}
-				return undefined;
-			};
-
 			let dbUri = getActiveDatabaseUri();
 			if (!dbUri) {
 				const picked = await vscode.window.showOpenDialog({
 					canSelectFiles: true,
 					canSelectFolders: false,
 					canSelectMany: false,
-					filters: {
-						'SQLite Database': ['db', 'sqlite', 'sqlite3'],
-						'All Files': ['*']
-					}
+					filters: getDatabaseDialogFilters()
 				});
 				if (!picked || picked.length === 0) {
 					return;
 				}
 				dbUri = picked[0];
-			}
-
-			if (!isDatabaseFile(dbUri)) {
-				vscode.window.showWarningMessage('Selected file is not a recognized database file');
-				return;
 			}
 
 			// Ensure the database is open in the custom editor.
@@ -188,23 +195,7 @@ export function activate(context: vscode.ExtensionContext) {
 	});
 
 	const checkpointWalCommand = vscode.commands.registerCommand('sqlite-intelliview-vscode.checkpointWal', async () => {
-		const isDatabasePath = (p: string) => ['.db', '.sqlite', '.sqlite3'].some(ext => p.toLowerCase().endsWith(ext));
-		const getActiveDatabasePath = (): string | undefined => {
-			const editorPath = vscode.window.activeTextEditor?.document.uri.fsPath;
-			if (editorPath && isDatabasePath(editorPath)) {
-				return editorPath;
-			}
-			const activeTab = vscode.window.tabGroups.activeTabGroup?.activeTab;
-			const input: any = activeTab?.input;
-			const inputUri: vscode.Uri | undefined = input && input.uri && typeof input.uri.fsPath === 'string' ? input.uri : undefined;
-			const inputPath = inputUri?.fsPath;
-			if (inputPath && isDatabasePath(inputPath)) {
-				return inputPath;
-			}
-			return undefined;
-		};
-
-		const dbPath = getActiveDatabasePath();
+		const dbPath = getActiveDatabaseUri()?.fsPath;
 		if (!dbPath) {
 			vscode.window.showWarningMessage('No database file is currently open');
 			return;
@@ -247,7 +238,7 @@ export function activate(context: vscode.ExtensionContext) {
 	);
 
 	// Show welcome message
-	vscode.window.showInformationMessage('SQLite IntelliView is ready! Click on .db files to open them.');
+	vscode.window.showInformationMessage('SQLite IntelliView is ready! Open a SQLite database file to get started.');
 }
 
 // This method is called when your extension is deactivated

--- a/src/fileExtensions.ts
+++ b/src/fileExtensions.ts
@@ -1,0 +1,44 @@
+import * as path from 'path';
+
+export const BUILT_IN_SQLITE_FILE_EXTENSIONS = Object.freeze([
+    'sqlite',
+    'sqlite3',
+    'db',
+    'db3',
+    's3db',
+    'sl3',
+]);
+
+const VALID_EXTENSION_PATTERN = /^[a-z0-9][a-z0-9_-]*$/i;
+
+export function normalizeSQLiteFileExtension(value: unknown): string | undefined {
+    if (typeof value !== 'string') {
+        return undefined;
+    }
+
+    const trimmed = value.trim();
+    const withoutLeadingDot = trimmed.startsWith('.') ? trimmed.slice(1) : trimmed;
+    if (!VALID_EXTENSION_PATTERN.test(withoutLeadingDot)) {
+        return undefined;
+    }
+
+    return withoutLeadingDot.toLowerCase();
+}
+
+export function getSQLiteFileExtensions(additionalExtensions: readonly unknown[] = []): string[] {
+    const extensions = new Set<string>(BUILT_IN_SQLITE_FILE_EXTENSIONS);
+
+    for (const value of additionalExtensions) {
+        const normalized = normalizeSQLiteFileExtension(value);
+        if (normalized) {
+            extensions.add(normalized);
+        }
+    }
+
+    return Array.from(extensions);
+}
+
+export function isSQLiteFilePath(filePath: string, additionalExtensions: readonly unknown[] = []): boolean {
+    const extension = normalizeSQLiteFileExtension(path.extname(filePath));
+    return extension !== undefined && getSQLiteFileExtensions(additionalExtensions).includes(extension);
+}

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -3,6 +3,12 @@ import * as assert from 'assert';
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
 import * as vscode from 'vscode';
+import {
+	BUILT_IN_SQLITE_FILE_EXTENSIONS,
+	getSQLiteFileExtensions,
+	isSQLiteFilePath,
+	normalizeSQLiteFileExtension,
+} from '../fileExtensions';
 // import * as myExtension from '../../extension';
 
 suite('Extension Test Suite', () => {
@@ -11,5 +17,66 @@ suite('Extension Test Suite', () => {
 	test('Sample test', () => {
 		assert.strictEqual(-1, [1, 2, 3].indexOf(5));
 		assert.strictEqual(-1, [1, 2, 3].indexOf(0));
+	});
+
+	test('recognizes every built-in SQLite extension', () => {
+		const expectedExtensions = ['sqlite', 'sqlite3', 'db', 'db3', 's3db', 'sl3'];
+		assert.deepStrictEqual([...BUILT_IN_SQLITE_FILE_EXTENSIONS], expectedExtensions);
+
+		for (const extension of expectedExtensions) {
+			assert.strictEqual(isSQLiteFilePath(`/tmp/database.${extension}`), true, extension);
+		}
+		assert.strictEqual(isSQLiteFilePath('/tmp/existing.db'), true);
+	});
+
+	test('matches built-in extensions case-insensitively', () => {
+		assert.strictEqual(isSQLiteFilePath('/tmp/database.DB3'), true);
+		assert.strictEqual(isSQLiteFilePath('/tmp/database.SqlItE3'), true);
+		assert.strictEqual(isSQLiteFilePath('/tmp/database.S3Db'), true);
+		assert.strictEqual(isSQLiteFilePath('/tmp/database.sL3'), true);
+	});
+
+	test('normalizes custom extensions with and without a leading dot', () => {
+		const configured = ['.database', 'sqlite-backup'];
+		assert.strictEqual(isSQLiteFilePath('/tmp/example.DATABASE', configured), true);
+		assert.strictEqual(isSQLiteFilePath('/tmp/example.SQLite-Backup', configured), true);
+	});
+
+	test('ignores duplicate and invalid custom extensions', () => {
+		const configured: unknown[] = [
+			'.database',
+			'DATABASE',
+			' database ',
+			'.DB',
+			'',
+			'   ',
+			'.',
+			'*.db',
+			'foo.bar',
+			'/tmp/db',
+			42,
+			null,
+		];
+		const extensions = getSQLiteFileExtensions(configured);
+
+		assert.strictEqual(extensions.filter(extension => extension === 'database').length, 1);
+		assert.deepStrictEqual(
+			extensions,
+			[...BUILT_IN_SQLITE_FILE_EXTENSIONS, 'database']
+		);
+	});
+
+	test('does not recognize unrelated or malformed filenames', () => {
+		assert.strictEqual(isSQLiteFilePath('/tmp/database.txt'), false);
+		assert.strictEqual(isSQLiteFilePath('/tmp/database.db.backup'), false);
+		assert.strictEqual(isSQLiteFilePath('/tmp/database'), false);
+		assert.strictEqual(isSQLiteFilePath('/tmp/.db'), false);
+	});
+
+	test('normalizes extension values safely', () => {
+		assert.strictEqual(normalizeSQLiteFileExtension(' .DaTaBase '), 'database');
+		assert.strictEqual(normalizeSQLiteFileExtension('sqlite-backup'), 'sqlite-backup');
+		assert.strictEqual(normalizeSQLiteFileExtension('foo.bar'), undefined);
+		assert.strictEqual(normalizeSQLiteFileExtension(undefined), undefined);
 	});
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["ES2022", "DOM"],
     "sourceMap": true,
     "rootDir": "src",
+    "outDir": "out",
     "strict": true /* enable all strict type-checking options */,
     "skipLibCheck": true /* Skip type checking of declaration files */
     /* Additional Checks */


### PR DESCRIPTION
## Summary

- centralize SQLite filename-extension normalization and matching
- add built-in support for `.sqlite`, `.sqlite3`, `.db`, `.db3`, `.s3db`, and `.sl3`, including case-insensitive matching
- add `sqliteIntelliView.additionalFileExtensions` for custom extensions in commands and file pickers
- allow explicit opens to rely on existing SQLite header/query validation instead of rejecting unknown suffixes
- update custom-editor selectors, Explorer context menus, watcher behavior, documentation, and tests

## Testing

- `npm test` (7 passing)
- `npm run check-types`
- `npm run build`
- `npx eslint "src/**/*.ts"`
- `npx vsce ls --yarn`
- `git diff --check`

## Notes

VS Code custom-editor associations, activation events, and Explorer context-menu contributions are static manifest data and cannot consume runtime settings. Custom-extension files can be opened through **SQLite IntelliView: Open SQLite Database**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added built-in support for additional SQLite extensions, including `.db3`, `.s3db` and `.sl3`.
  * File and context-menu recognition is now case-insensitive.
  * Added the `sqliteIntelliView.additionalFileExtensions` setting for custom extensions.
  * Updated database file pickers and editor associations to use configured extensions.

* **Bug Fixes**
  * Improved refresh behaviour for database files and related WAL/SHM files.

* **Documentation**
  * Updated the README and changelog with the expanded extension support and configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->