### PR TITLE
 Fix cell edits targeting the wrong SQLite row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 - Fixed a critical data-integrity bug where cell edits could update a different database row when grid position and SQLite scan order diverged after sorting, filtering, pagination, or virtual scrolling.
 - Cell updates now use stable declared primary-key identities (including text and composite keys) or SQLite `rowid`, bind all values, and require exactly one changed row before reporting success.
-- Tables without a safe unique row identity are now read-only, while primary-key edits retain the original identity for the update and refresh it after saving.
+- **Breaking:** Tables for which SQLite IntelliView cannot derive a stable row identity are now read-only instead of allowing potentially unsafe edits. Normal `rowid` tables remain editable. For tables whose SQLite `rowid` aliases are shadowed, define a non-null primary key to restore editing. Views remain read-only. Primary-key edits retain the original identity for the update and refresh it after saving.
 
 ## [0.4.9] - 2026-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 - Built-in recognition for `.db3`, `.s3db`, and `.sl3` databases, with case-insensitive matching for all supported SQLite extensions.
 - `sqliteIntelliView.additionalFileExtensions` for recognizing custom SQLite filename extensions in commands and file pickers.
 
+### Fixed
+
+- Fixed a critical data-integrity bug where cell edits could update a different database row when grid position and SQLite scan order diverged after sorting, filtering, pagination, or virtual scrolling.
+- Cell updates now use stable declared primary-key identities (including text and composite keys) or SQLite `rowid`, bind all values, and require exactly one changed row before reporting success.
+- Tables without a safe unique row identity are now read-only, while primary-key edits retain the original identity for the update and refresh it after saving.
+
 ## [0.4.9] - 2026-04-27
 
 ### Changed

--- a/media/events.js
+++ b/media/events.js
@@ -2760,6 +2760,14 @@ function initializeTableEvents(tableWrapper) {
       }
     });
 
+    tableWrapper.addEventListener("input", (e) => {
+      const target = e.target instanceof HTMLElement ? e.target : null;
+      if (!target?.classList.contains("cell-input")) {
+        return;
+      }
+      target.closest(".data-cell")?.setAttribute("data-edit-dirty", "true");
+    });
+
     tableWrapper.addEventListener("focusout", (e) => {
       const target = e.target instanceof HTMLElement ? e.target : null;
       if (!target) {
@@ -2808,13 +2816,17 @@ function startCellEditing(cell) {
   // Get current value
   const cellContent = cell.querySelector(".cell-content");
   const originalValue = cellContent.getAttribute("data-original-value") || "";
+  const nullAttribute = cellContent.getAttribute("data-original-is-null");
   const isNull =
-    cellContent.querySelector("em") &&
-    cellContent.textContent.trim() === "NULL";
+    nullAttribute === "true" ||
+    (nullAttribute === null &&
+      cellContent.querySelector("em") &&
+      cellContent.textContent.trim() === "NULL");
   const currentValue = isNull ? "" : originalValue;
 
   // Set up editing state
   cell.classList.add("editing");
+  cell.setAttribute("data-edit-dirty", "false");
   const input = cell.querySelector(".cell-input");
   if (input) {
     /** @type {HTMLInputElement} */ (input).value = currentValue;
@@ -2879,12 +2891,18 @@ function saveCellEdit(cell) {
   }
 
   const newValue = /** @type {HTMLInputElement} */ (input).value;
-  const originalValue =
-    cell.querySelector(".cell-content")?.getAttribute("data-original-value") ||
-    "";
+  const cellContent = cell.querySelector(".cell-content");
+  const originalValue = cellContent?.getAttribute("data-original-value") || "";
+  const nullAttribute = cellContent?.getAttribute("data-original-is-null");
+  const originalIsNull =
+    nullAttribute === "true" ||
+    (nullAttribute === null &&
+      cellContent?.querySelector("em") &&
+      cellContent.textContent.trim() === "NULL");
+  const editIsDirty = cell.getAttribute("data-edit-dirty") === "true";
 
   // Check if value actually changed
-  if (newValue === originalValue) {
+  if (newValue === originalValue && (!originalIsNull || !editIsDirty)) {
     cancelCellEdit(cell);
     return;
   }
@@ -2994,6 +3012,7 @@ function cancelCellEdit(cell) {
   }
   cell.classList.remove("editing", "saving", "error");
   cell.removeAttribute("data-edit-request-id");
+  cell.removeAttribute("data-edit-dirty");
   const input = cell.querySelector(".cell-input");
   if (input) {
     /** @type {HTMLInputElement} */ (input).value = "";
@@ -3060,12 +3079,14 @@ function handleCellUpdateSuccess(message) {
     // Update the cell content
     const cellContent = cell.querySelector(".cell-content");
     if (cellContent) {
+      const isNull = newValue === null || newValue === undefined;
       cellContent.setAttribute(
         "data-original-value",
-        newValue === null || newValue === undefined ? "" : String(newValue),
+        isNull ? "" : String(newValue),
       );
+      cellContent.setAttribute("data-original-is-null", String(isNull));
 
-      if (newValue === null || newValue === undefined) {
+      if (isNull) {
         cellContent.innerHTML = "<em>NULL</em>";
       } else {
         cellContent.textContent = newValue;
@@ -3075,6 +3096,7 @@ function handleCellUpdateSuccess(message) {
     // Remove editing state
     cell.classList.remove("editing", "saving", "error");
     cell.removeAttribute("data-edit-request-id");
+    cell.removeAttribute("data-edit-dirty");
 
     // Show success feedback
     cell.style.backgroundColor = "var(--vscode-list-activeSelectionBackground)";
@@ -3565,7 +3587,17 @@ function handleTableDataDelta({
       if (cell) {
         const cc = cell.querySelector(".cell-content");
         if (cc) {
-          cc.textContent = val === null ? "" : String(val);
+          const isNull = val === null || val === undefined;
+          cc.setAttribute(
+            "data-original-value",
+            isNull ? "" : String(val),
+          );
+          cc.setAttribute("data-original-is-null", String(isNull));
+          if (isNull) {
+            cc.innerHTML = "<em>NULL</em>";
+          } else {
+            cc.textContent = String(val);
+          }
         }
       }
     });

--- a/media/events.js
+++ b/media/events.js
@@ -57,19 +57,6 @@ function isExtensionToWebviewMessage(value) {
 }
 
 /**
- * Best-effort stringify for debug logging; never throw on circular values.
- * @param {unknown} value
- * @returns {string}
- */
-function safeDebugStringify(value) {
-  try {
-    return JSON.stringify(value);
-  } catch (_) {
-    return "[unserializable message]";
-  }
-}
-
-/**
  * Initialize all event listeners
  */
 /**
@@ -705,21 +692,13 @@ function handleExtensionMessage(event) {
   const rawMessage = event.data;
   if (!isExtensionToWebviewMessage(rawMessage)) {
     if (window.debug) {
-      window.debug.debug(
-        `[Events] Ignoring invalid extension message: ${safeDebugStringify(
-          rawMessage,
-        )}`,
-      );
+      window.debug.debug("[Events] Ignoring invalid extension message");
     }
     return;
   }
   const message = rawMessage;
   if (window.debug) {
-    window.debug.debug(
-      `[Events] Received message: ${message.type}, ${safeDebugStringify(
-        message,
-      )}`,
-    );
+    window.debug.debug(`[Events] Received message: ${message.type}`);
   }
 
   // Some errors should force the sidebar open so the user can enter a key, etc.
@@ -3086,7 +3065,7 @@ function handleCellUpdateSuccess(message) {
         newValue === null || newValue === undefined ? "" : String(newValue),
       );
 
-      if (newValue === null || newValue === "") {
+      if (newValue === null || newValue === undefined) {
         cellContent.innerHTML = "<em>NULL</em>";
       } else {
         cellContent.textContent = newValue;

--- a/media/events.js
+++ b/media/events.js
@@ -49,9 +49,9 @@ function isExtensionToWebviewMessage(value) {
     !!value &&
     typeof value === "object" &&
     "type" in value &&
-    typeof /** @type {{type?: unknown}} */ (value).type === "string" &&
+    typeof (/** @type {{type?: unknown}} */ (value).type) === "string" &&
     EXTENSION_TO_WEBVIEW_MESSAGE_TYPES.has(
-      /** @type {{type: string}} */ (value).type
+      /** @type {{type: string}} */ (value).type,
     )
   );
 }
@@ -105,7 +105,7 @@ function initializeEventListeners() {
     window.debug.debug(
       `[events.js] initializeEventListeners called. Guard: ${
         window["_eventListenersInitialized"]
-      }, Stack: ${new Error().stack}`
+      }, Stack: ${new Error().stack}`,
     );
   }
   /** @type {any} */
@@ -203,7 +203,7 @@ function initializeEventListeners() {
   window["_eventListenersInitialized"] = true;
   if (window.debug) {
     window.debug.debug(
-      "[events.js] Event listeners registered. Guard set to true."
+      "[events.js] Event listeners registered. Guard set to true.",
     );
   }
 }
@@ -573,7 +573,7 @@ function persistFallbackReloadSnapshot() {
     const snapshot = buildFallbackReloadSnapshot();
     sessionStorage.setItem(
       FALLBACK_RELOAD_SNAPSHOT_KEY,
-      JSON.stringify(snapshot)
+      JSON.stringify(snapshot),
     );
     return true;
   } catch (_) {
@@ -707,8 +707,8 @@ function handleExtensionMessage(event) {
     if (window.debug) {
       window.debug.debug(
         `[Events] Ignoring invalid extension message: ${safeDebugStringify(
-          rawMessage
-        )}`
+          rawMessage,
+        )}`,
       );
     }
     return;
@@ -717,8 +717,8 @@ function handleExtensionMessage(event) {
   if (window.debug) {
     window.debug.debug(
       `[Events] Received message: ${message.type}, ${safeDebugStringify(
-        message
-      )}`
+        message,
+      )}`,
     );
   }
 
@@ -809,7 +809,7 @@ function handleExtensionMessage(event) {
           showSuccess(
             bytes
               ? `Blob saved (${bytes.toLocaleString()} bytes)`
-              : "Blob saved"
+              : "Blob saved",
           );
         }
       } else {
@@ -907,8 +907,7 @@ function handleUpdate(message) {
   const currentState =
     typeof getCurrentState === "function" ? getCurrentState() : {};
   const isInitialDatabaseBind =
-    !!message.databasePath &&
-    (!currentState || !currentState.databasePath);
+    !!message.databasePath && (!currentState || !currentState.databasePath);
 
   if (
     settings &&
@@ -963,7 +962,7 @@ function handleUpdate(message) {
     if (typeof window.updateState === "function") {
       window.updateState(
         { allTables: message.tables },
-        { renderTabs: false, renderSidebar: false }
+        { renderTabs: false, renderSidebar: false },
       );
     }
     displayTablesList(message.tables);
@@ -988,8 +987,8 @@ function handleDatabaseInfo(message) {
   if (window.debug) {
     window.debug.debug(
       `[Events] handleDatabaseInfo called with message: ${JSON.stringify(
-        message
-      )}`
+        message,
+      )}`,
     );
   }
 
@@ -1027,7 +1026,7 @@ function handleDatabaseInfo(message) {
     if (typeof window.updateState === "function") {
       window.updateState(
         { allTables: message.tables || [] },
-        { renderTabs: false, renderSidebar: false }
+        { renderTabs: false, renderSidebar: false },
       );
     }
     if (typeof displayTablesList !== "undefined") {
@@ -1063,7 +1062,11 @@ function handleDatabaseInfo(message) {
       if (s && s.activeTab !== activeMainTab) {
         window.updateState(
           { activeTab: activeMainTab },
-          { renderTabs: false, renderSidebar: false, persistState: "debounced" }
+          {
+            renderTabs: false,
+            renderSidebar: false,
+            persistState: "debounced",
+          },
         );
       }
     }
@@ -1110,7 +1113,7 @@ function handleDatabaseInfo(message) {
         if (!state.selectedTable || !state.activeTable) {
           window.updateState(
             { selectedTable: selected, activeTable: selected },
-            { renderTabs: false, renderSidebar: false }
+            { renderTabs: false, renderSidebar: false },
           );
         }
       }
@@ -1140,8 +1143,8 @@ function handleDatabaseInfo(message) {
             vs && typeof vs.pageSize === "number"
               ? vs.pageSize
               : typeof state.pageSize === "number"
-              ? state.pageSize
-              : 100;
+                ? state.pageSize
+                : 100;
           window.vscode.postMessage({
             type: "getTableData",
             tableName: selected,
@@ -1159,7 +1162,7 @@ function handleDatabaseInfo(message) {
   } else {
     if (window.debug) {
       window.debug.debug(
-        `[Events] Database connection failed: ${message.error}`
+        `[Events] Database connection failed: ${message.error}`,
       );
     }
 
@@ -1182,7 +1185,7 @@ function handleDatabaseInfo(message) {
     // Show connection section for retry when database is disconnected
     if (window.debug) {
       window.debug.debug(
-        "Database connection failed, showing connection section"
+        "Database connection failed, showing connection section",
       );
     }
     showConnectionSection();
@@ -1206,7 +1209,7 @@ function handleQueryResult(message) {
     const rowText = rowCount === 1 ? "row" : "rows";
     if (typeof showSuccess !== "undefined") {
       showSuccess(
-        `Query executed successfully. ${rowCount} ${rowText} returned. Results are available in the Data tab.`
+        `Query executed successfully. ${rowCount} ${rowText} returned. Results are available in the Data tab.`,
       );
     }
   } else {
@@ -1233,7 +1236,7 @@ function handleQueryResult(message) {
       try {
         if (window.debug) {
           window.debug.debug(
-            "handleQueryResult: Ensuring Monaco editor responsiveness"
+            "handleQueryResult: Ensuring Monaco editor responsiveness",
           );
         }
 
@@ -1263,7 +1266,7 @@ function handleQueryResult(message) {
         if (window.debug) {
           window.debug.error(
             "handleQueryResult: Error ensuring editor responsiveness:",
-            error
+            error,
           );
         }
         // If there's an issue, try refreshing the editor
@@ -1369,7 +1372,7 @@ function handleTableRowCount(message) {
   }
 
   const wrapper = document.querySelector(
-    `.enhanced-table-wrapper[data-table="${tableName}"]`
+    `.enhanced-table-wrapper[data-table="${tableName}"]`,
   );
   if (!wrapper) {
     return;
@@ -1380,11 +1383,11 @@ function handleTableRowCount(message) {
 
   const pageSize = parseInt(
     wrapper.getAttribute("data-page-size") || "100",
-    10
+    10,
   );
   const currentPage = parseInt(
     wrapper.getAttribute("data-current-page") || "1",
-    10
+    10,
   );
   const totalPages = Math.ceil(totalRows / pageSize);
 
@@ -1396,7 +1399,7 @@ function handleTableRowCount(message) {
   const startIndex = (currentPage - 1) * pageSize;
   const pageRows = parseInt(wrapper.getAttribute("data-page-rows") || "0", 10);
   const renderedRows = wrapper.querySelectorAll(
-    "tbody tr.resizable-row"
+    "tbody tr.resizable-row",
   ).length;
   const endIndex = startIndex + (pageRows || renderedRows);
   const visibleRows = wrapper.querySelector(".visible-rows");
@@ -1416,7 +1419,7 @@ function handleTableRowCount(message) {
       paginationContainer.innerHTML = window.createPaginationControls(
         currentPage,
         totalPages,
-        tableId
+        tableId,
       );
     } else {
       paginationContainer.innerHTML = "";
@@ -1454,12 +1457,12 @@ function handleERDiagram(message) {
     if (typeof addDebugMessage !== "undefined") {
       addDebugMessage("Received ER diagram data from extension");
       addDebugMessage(
-        `Found ${message.tables ? message.tables.length : 0} tables`
+        `Found ${message.tables ? message.tables.length : 0} tables`,
       );
       addDebugMessage(
         `Found ${
           message.relationships ? message.relationships.length : 0
-        } relationships`
+        } relationships`,
       );
     }
 
@@ -1501,7 +1504,7 @@ function handleERDiagram(message) {
       showDiagramError(message.error || "Unknown error");
     } else if (typeof showError !== "undefined") {
       showError(
-        "Failed to generate ER diagram: " + (message.error || "Unknown error")
+        "Failed to generate ER diagram: " + (message.error || "Unknown error"),
       );
     }
   }
@@ -1564,7 +1567,7 @@ function captureCurrentDataViewState() {
     tableKey,
     { page: currentPage, pageSize, searchTerm, scrollTop, scrollLeft },
     // Tab switches also update `activeTable/selectedTable`, so avoid extra persistence work here.
-    { renderTabs: false, renderSidebar: false, persistState: "none" }
+    { renderTabs: false, renderSidebar: false, persistState: "none" },
   );
 }
 
@@ -1627,7 +1630,7 @@ function applyTabViewStateToWrapper(tableWrapper, tabKey) {
         }
       } else {
         const header = table.querySelector(
-          `th[data-column-name="${columnName}"]`
+          `th[data-column-name="${columnName}"]`,
         );
         const colIndex = header
           ? parseInt(header.getAttribute("data-column") || "-1", 10)
@@ -1662,14 +1665,14 @@ function applyTabViewStateToWrapper(tableWrapper, tabKey) {
                 typeof window.getCellValue === "function"
                   ? window.getCellValue(aCell)
                   : aCell && aCell.textContent
-                  ? aCell.textContent.trim()
-                  : "";
+                    ? aCell.textContent.trim()
+                    : "";
               const bValue =
                 typeof window.getCellValue === "function"
                   ? window.getCellValue(bCell)
                   : bCell && bCell.textContent
-                  ? bCell.textContent.trim()
-                  : "";
+                    ? bCell.textContent.trim()
+                    : "";
               return cmp(aValue ?? "", bValue ?? "", dir);
             });
             rows.forEach((row) => tbody.appendChild(row));
@@ -1754,7 +1757,7 @@ function applyTabViewStateToWrapper(tableWrapper, tabKey) {
         const colIndex = th.getAttribute("data-column");
         if (colIndex) {
           const col = table.querySelector(
-            `colgroup col[data-column="${colIndex}"]`
+            `colgroup col[data-column="${colIndex}"]`,
           );
           if (col && col instanceof HTMLElement) {
             col.style.width = `${w}px`;
@@ -1842,11 +1845,11 @@ function applyTabViewStateToWrapper(tableWrapper, tabKey) {
   const applyScroll = (attempt = 0) => {
     const maxTop = Math.max(
       0,
-      scrollContainer.scrollHeight - scrollContainer.clientHeight
+      scrollContainer.scrollHeight - scrollContainer.clientHeight,
     );
     const maxLeft = Math.max(
       0,
-      scrollContainer.scrollWidth - scrollContainer.clientWidth
+      scrollContainer.scrollWidth - scrollContainer.clientWidth,
     );
     const desiredTop = Math.max(0, Math.min(maxTop, targetTop));
     const desiredLeft = Math.max(0, Math.min(maxLeft, targetLeft));
@@ -1859,7 +1862,7 @@ function applyTabViewStateToWrapper(tableWrapper, tabKey) {
     } else {
       scrollContainer.removeAttribute("data-viewstate-restoring-scroll");
       const prev = scrollContainer.getAttribute(
-        "data-viewstate-prev-scroll-behavior"
+        "data-viewstate-prev-scroll-behavior",
       );
       if (prev !== null) {
         if (prev) {
@@ -1923,10 +1926,10 @@ function displayTablesList(tables) {
   const elements = getAllDOMElements ? getAllDOMElements() : {};
   if (window.debug) {
     window.debug.debug(
-      `[Events] displayTablesList called with: ${JSON.stringify(tables)}`
+      `[Events] displayTablesList called with: ${JSON.stringify(tables)}`,
     );
     window.debug.debug(
-      `[Events] tablesListElement: ${elements.tablesListElement}`
+      `[Events] tablesListElement: ${elements.tablesListElement}`,
     );
   }
 
@@ -1946,7 +1949,7 @@ function displayTablesList(tables) {
   if (typeof window.updateState === "function") {
     window.updateState(
       { allTables: tables },
-      { renderTabs: false, renderSidebar: false }
+      { renderTabs: false, renderSidebar: false },
     );
   }
 
@@ -1960,8 +1963,8 @@ function displayTablesList(tables) {
       const isSelected = state.selectedTable === table.name;
       return `
         <div class="table-item${isSelected ? " selected" : ""}" data-table="${
-        table.name
-      }">
+          table.name
+        }">
           <span class="table-name">${table.name}</span>
         </div>
       `;
@@ -1996,7 +1999,7 @@ function displayTablesList(tables) {
 
   if (window.debug) {
     window.debug.debug(
-      "[Events] Tables HTML generated, adding event listeners..."
+      "[Events] Tables HTML generated, adding event listeners...",
     );
   }
 
@@ -2030,7 +2033,7 @@ function displayTablesList(tables) {
     if (openTables.length === 0) {
       // Map to string names if needed
       const tableNames = tables.map((t) =>
-        typeof t === "string" ? t : t.name
+        typeof t === "string" ? t : t.name,
       );
       if (typeof window.openTableTab === "function" && tableNames[0]) {
         window.openTableTab(tableNames[0]);
@@ -2046,7 +2049,7 @@ function displayTablesList(tables) {
 
   if (window.debug) {
     window.debug.debug(
-      `[Events] Event listeners added to ${tables.length} tables`
+      `[Events] Event listeners added to ${tables.length} tables`,
     );
   }
 }
@@ -2148,7 +2151,7 @@ function displayQueryResults(data, columns, query = null) {
   const now = new Date();
   const pad = (n) => n.toString().padStart(2, "0");
   const dateStr = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(
-    now.getDate()
+    now.getDate(),
   )} ${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}`;
   let tabKey = `Results (${dateStr})`;
   let tabLabel = tabKey;
@@ -2262,7 +2265,7 @@ function restoreEditorState(editorState) {
     if (window.debug) {
       window.debug.debug(
         "restoreEditorState: Restoring editor state",
-        editorState
+        editorState,
       );
     }
 
@@ -2303,14 +2306,14 @@ function restoreEditorState(editorState) {
 
     if (window.debug) {
       window.debug.debug(
-        "restoreEditorState: Editor state restored successfully"
+        "restoreEditorState: Editor state restored successfully",
       );
     }
   } catch (error) {
     if (window.debug) {
       window.debug.debug(
         "restoreEditorState: Error restoring editor state:",
-        error
+        error,
       );
     }
   }
@@ -2343,7 +2346,7 @@ function displayTableSchema(data, columns, foreignKeys = []) {
 
   // Initialize table features for the new table
   const tableWrapper = elements.schemaContent.querySelector(
-    ".enhanced-table-wrapper"
+    ".enhanced-table-wrapper",
   );
   if (tableWrapper && typeof initializeTableEvents !== "undefined") {
     initializeTableEvents(tableWrapper);
@@ -2378,7 +2381,7 @@ function displayTableData(data, columns, tableName, options = {}) {
 
   // Initialize table features for the new table
   const tableWrapper = elements.dataContent.querySelector(
-    ".enhanced-table-wrapper"
+    ".enhanced-table-wrapper",
   );
   if (tableWrapper && typeof initializeTableEvents !== "undefined") {
     initializeTableEvents(tableWrapper);
@@ -2481,7 +2484,7 @@ function initializeTableEvents(tableWrapper) {
           window.setTabViewState(
             tableKey,
             { searchTerm },
-            { renderTabs: false, renderSidebar: false }
+            { renderTabs: false, renderSidebar: false },
           );
         }
       });
@@ -2503,7 +2506,7 @@ function initializeTableEvents(tableWrapper) {
           window.setTabViewState(
             tableKey,
             { searchTerm: "" },
-            { renderTabs: false, renderSidebar: false }
+            { renderTabs: false, renderSidebar: false },
           );
         }
       });
@@ -2511,7 +2514,7 @@ function initializeTableEvents(tableWrapper) {
 
     // Scroll position persistence (throttled)
     const scrollContainer = tableWrapper.querySelector(
-      ".table-scroll-container"
+      ".table-scroll-container",
     );
     if (
       scrollContainer &&
@@ -2544,7 +2547,7 @@ function initializeTableEvents(tableWrapper) {
               renderTabs: false,
               renderSidebar: false,
               persistState: "debounced",
-            }
+            },
           );
         }, 400);
       });
@@ -2569,7 +2572,7 @@ function initializeTableEvents(tableWrapper) {
     });
     // Column action buttons (including pin buttons)
     const actionBtns = tableWrapper.querySelectorAll(
-      ".column-action-btn, .pin-btn"
+      ".column-action-btn, .pin-btn",
     );
     actionBtns.forEach((btn) => {
       btn.addEventListener("click", (e) => {
@@ -2647,9 +2650,9 @@ function initializeTableEvents(tableWrapper) {
           target.closest(".enhanced-table-wrapper") || tableWrapper;
         const val = parseInt(
           String(
-            target instanceof HTMLInputElement ? target.value : target.value
+            target instanceof HTMLInputElement ? target.value : target.value,
           ),
-          10
+          10,
         );
         if (!isNaN(val) && typeof window.updateTablePage === "function") {
           ke.preventDefault();
@@ -2667,9 +2670,9 @@ function initializeTableEvents(tableWrapper) {
           target.closest(".enhanced-table-wrapper") || tableWrapper;
         const val = parseInt(
           String(
-            target instanceof HTMLInputElement ? target.value : target.value
+            target instanceof HTMLInputElement ? target.value : target.value,
           ),
-          10
+          10,
         );
         if (!isNaN(val) && typeof window.updateTablePage === "function") {
           window.updateTablePage(wrapper, val);
@@ -2880,6 +2883,17 @@ function saveCellEdit(cell) {
     return;
   }
 
+  const win = /** @type {any} */ (window);
+  const activeRequestId = cell.getAttribute("data-edit-request-id");
+  if (
+    cell.classList.contains("saving") ||
+    (activeRequestId &&
+      win.__pendingCellEdits instanceof Map &&
+      win.__pendingCellEdits.has(activeRequestId))
+  ) {
+    return;
+  }
+
   const input = cell.querySelector(".cell-input");
   if (!input) {
     return;
@@ -2904,7 +2918,8 @@ function saveCellEdit(cell) {
   const tableId = wrapper?.getAttribute("data-table-id") || "";
   const localIndex = parseInt(row?.getAttribute("data-local-index") || "", 10);
   const tableStash = /** @type {any} */ (window).__tableDataStash;
-  const stashedTable = tableId && tableStash instanceof Map ? tableStash.get(tableId) : null;
+  const stashedTable =
+    tableId && tableStash instanceof Map ? tableStash.get(tableId) : null;
   const rowIdentity =
     stashedTable &&
     Array.isArray(stashedTable.rowIdentities) &&
@@ -2918,7 +2933,7 @@ function saveCellEdit(cell) {
     }
     if (typeof showError !== "undefined") {
       showError(
-        "This row cannot be identified safely. Refresh the table before editing."
+        "This row cannot be identified safely. Refresh the table before editing.",
       );
     }
     cancelCellEdit(cell);
@@ -2928,7 +2943,6 @@ function saveCellEdit(cell) {
   // Show saving state
   cell.classList.add("saving");
   cell.classList.remove("error");
-  const win = /** @type {any} */ (window);
   win.__cellEditSequence = Number(win.__cellEditSequence || 0) + 1;
   const requestId = `cell-edit-${Date.now()}-${win.__cellEditSequence}`;
   cell.setAttribute("data-edit-request-id", requestId);
@@ -2967,10 +2981,9 @@ function findPendingEditCell(requestId) {
     return null;
   }
   return Array.from(
-    document.querySelectorAll(".data-cell[data-edit-request-id]")
+    document.querySelectorAll(".data-cell[data-edit-request-id]"),
   ).find(
-    (candidate) =>
-      candidate.getAttribute("data-edit-request-id") === requestId
+    (candidate) => candidate.getAttribute("data-edit-request-id") === requestId,
   );
 }
 
@@ -3017,19 +3030,24 @@ function handleCellUpdateSuccess(message) {
 
   const pending = takePendingCellEdit(requestId);
   const cell = pending?.cell || findPendingEditCell(requestId);
-  const tableId = pending?.tableId || cell?.closest(".enhanced-table-wrapper")?.getAttribute("data-table-id") || "";
+  const tableId =
+    pending?.tableId ||
+    cell?.closest(".enhanced-table-wrapper")?.getAttribute("data-table-id") ||
+    "";
   const localIndex = Number.isInteger(pending?.localIndex)
     ? pending.localIndex
     : parseInt(
-        cell?.closest("tr[data-local-index]")?.getAttribute("data-local-index") || "",
-        10
+        cell
+          ?.closest("tr[data-local-index]")
+          ?.getAttribute("data-local-index") || "",
+        10,
       );
   const columnIndex = Number.isInteger(pending?.columnIndex)
     ? pending.columnIndex
     : parseInt(cell?.getAttribute("data-column") || "", 10);
   const wrapper = Array.from(
-    document.querySelectorAll(".enhanced-table-wrapper[data-table-id]")
-  ).find(candidate => candidate.getAttribute("data-table-id") === tableId);
+    document.querySelectorAll(".enhanced-table-wrapper[data-table-id]"),
+  ).find((candidate) => candidate.getAttribute("data-table-id") === tableId);
   const tableStash = /** @type {any} */ (window).__tableDataStash;
   const stashedTable =
     tableId && tableStash instanceof Map ? tableStash.get(tableId) : null;
@@ -3065,7 +3083,7 @@ function handleCellUpdateSuccess(message) {
     if (cellContent) {
       cellContent.setAttribute(
         "data-original-value",
-        newValue === null || newValue === undefined ? "" : String(newValue)
+        newValue === null || newValue === undefined ? "" : String(newValue),
       );
 
       if (newValue === null || newValue === "") {
@@ -3143,8 +3161,8 @@ function handleDeleteRowSuccess(message) {
   if (window.debug) {
     window.debug.debug(
       `[Events] Row deleted successfully from ${tableName}: ${JSON.stringify(
-        rowId
-      )}`
+        rowId,
+      )}`,
     );
   }
 }
@@ -3165,7 +3183,7 @@ function handleDeleteRowError(message) {
 
   if (window.debug) {
     window.debug.debug(
-      `[Events] Failed to delete row from ${tableName}: ${message.message}`
+      `[Events] Failed to delete row from ${tableName}: ${message.message}`,
     );
   }
 }
@@ -3299,19 +3317,19 @@ function handleTableDataDelta({
   // Capture old total count BEFORE updating anything (for notification)
   let oldTotalCountForNotification = 0;
   const wrapperForOldCount = document.querySelector(
-    `.enhanced-table-wrapper[data-table="${tableName}"]`
+    `.enhanced-table-wrapper[data-table="${tableName}"]`,
   );
   if (wrapperForOldCount) {
     oldTotalCountForNotification = parseInt(
       wrapperForOldCount.getAttribute("data-total-rows") || "0",
-      10
+      10,
     );
   }
 
   // Update the total count display if provided
   if (totalCount !== null) {
     const wrapper = document.querySelector(
-      `.enhanced-table-wrapper[data-table="${tableName}"]`
+      `.enhanced-table-wrapper[data-table="${tableName}"]`,
     );
     if (wrapper) {
       // Update the header "125 RECORDS" count
@@ -3344,11 +3362,11 @@ function handleTableDataDelta({
       // Update pagination controls to reflect new total count
       const currentPage = parseInt(
         wrapper.getAttribute("data-current-page") || "1",
-        10
+        10,
       );
       const pageSize = parseInt(
         wrapper.getAttribute("data-page-size") || "100",
-        10
+        10,
       );
       const totalPages = Math.ceil(totalCount / pageSize);
 
@@ -3365,7 +3383,7 @@ function handleTableDataDelta({
           paginationContainer.innerHTML = window.createPaginationControls(
             currentPage,
             totalPages,
-            tableId
+            tableId,
           );
 
           if (window.debug) {
@@ -3432,7 +3450,7 @@ function handleTableDataDelta({
       const now = Date.now();
       const store =
         /** @type {any} */ (window).__externalDeltaNotificationTimes ||
-        ((/** @type {any} */ (window).__externalDeltaNotificationTimes = {}));
+        /** @type {any} */ (window.__externalDeltaNotificationTimes = {});
       const lastAt =
         typeof store[dedupeKey] === "number" ? store[dedupeKey] : 0;
 
@@ -3441,7 +3459,7 @@ function handleTableDataDelta({
         window.showNotification(
           `Database files changed (likely WAL checkpoint/refresh), but no visible changes were detected in ${tableName} table.`,
           "info",
-          5000
+          5000,
         );
       }
     } else {
@@ -3450,7 +3468,7 @@ function handleTableDataDelta({
   }
 
   const wrapper = document.querySelector(
-    `.enhanced-table-wrapper[data-table="${tableName}"]`
+    `.enhanced-table-wrapper[data-table="${tableName}"]`,
   );
   if (!wrapper) {
     if (window.debug) {
@@ -3477,7 +3495,7 @@ function handleTableDataDelta({
       .map((rowIndex) => toLocal(rowIndex))
       .filter(
         (local) =>
-          Number.isFinite(local) && local >= 0 && local < vs.pageData.length
+          Number.isFinite(local) && local >= 0 && local < vs.pageData.length,
       )
       .sort((a, b) => b - a);
     deleteLocals.forEach((local) => {
@@ -3495,7 +3513,7 @@ function handleTableDataDelta({
           Number.isFinite(x.local) &&
           x.local >= 0 &&
           x.local <= pageSize &&
-          Array.isArray(x.rowData)
+          Array.isArray(x.rowData),
       )
       .sort((a, b) => a.local - b.local);
     insertLocals.forEach(({ local, rowData }) => {
@@ -3590,7 +3608,7 @@ function handleTableDataDelta({
       });
       // Use renderTableRows to generate the new row HTML, but robustly patch FK cells after creation
       let columns = Array.from(wrapper.querySelectorAll("thead th")).map((th) =>
-        th.getAttribute("data-column-name")
+        th.getAttribute("data-column-name"),
       );
       // Fallback: if any column name is missing, try to get from global schema (handle window typing)
       /** @type {any} */ const win =
@@ -3606,7 +3624,7 @@ function handleTableDataDelta({
             if (window.debug) {
               window.debug.debug(
                 "[events.js] No columns found in global schema for table",
-                tableName
+                tableName,
               );
             }
           }
@@ -3615,7 +3633,7 @@ function handleTableDataDelta({
             window.debug.debug(
               "[events.js] Some column names missing in <th> for table",
               tableName,
-              columns
+              columns,
             );
           }
         }
@@ -3716,7 +3734,7 @@ function handleTableDataDelta({
           window.debug.debug(
             "[events.js] Failed to create new row for insert",
             rowIndex,
-            rowData
+            rowData,
           );
         }
       }
@@ -3754,7 +3772,7 @@ function handleTableDataDelta({
   // After all new rows are inserted via delta, re-initialize table events for the wrapper
   // Diagnostic: log new rows and wrapper state before and after initialization
   const newRows = wrapper.querySelectorAll(
-    "tr[data-rowid]:not([data-initialized])"
+    "tr[data-rowid]:not([data-initialized])",
   );
   if (window.debug) {
     window.debug.debug("[Delta Debug] New rows before init:", newRows);
@@ -3763,7 +3781,7 @@ function handleTableDataDelta({
       "[Delta Debug] Guard before table event init:",
       window["_eventListenersInitialized"],
       "Stack:",
-      new Error().stack
+      new Error().stack,
     );
   }
   // Only initialize table events, never global events here
@@ -3777,7 +3795,7 @@ function handleTableDataDelta({
       "[Delta Debug] Guard after table event init:",
       window["_eventListenersInitialized"],
       "Stack:",
-      new Error().stack
+      new Error().stack,
     );
   }
 }

--- a/media/events.js
+++ b/media/events.js
@@ -1351,6 +1351,9 @@ function handleTableData(message) {
         message.totalRows !== undefined,
       backendPaginated: true,
       foreignKeys: message.foreignKeys,
+      rowIdentities: message.rowIdentities,
+      allowEditing: message.editable === true,
+      editError: message.editError,
     });
   } else {
     if (typeof showError !== "undefined") {
@@ -2895,12 +2898,28 @@ function saveCellEdit(cell) {
 
   // Get cell metadata
   const tableName = getCurrentTableName();
-  const rowIndex = parseInt(cell.getAttribute("data-row-index"));
   const columnName = cell.getAttribute("data-column-name");
+  const row = cell.closest("tr[data-local-index]");
+  const wrapper = cell.closest(".enhanced-table-wrapper");
+  const tableId = wrapper?.getAttribute("data-table-id") || "";
+  const localIndex = parseInt(row?.getAttribute("data-local-index") || "", 10);
+  const tableStash = /** @type {any} */ (window).__tableDataStash;
+  const stashedTable = tableId && tableStash instanceof Map ? tableStash.get(tableId) : null;
+  const rowIdentity =
+    stashedTable &&
+    Array.isArray(stashedTable.rowIdentities) &&
+    Number.isInteger(localIndex)
+      ? stashedTable.rowIdentities[localIndex]
+      : null;
 
-  if (!tableName || isNaN(rowIndex) || !columnName) {
+  if (!tableName || !columnName || !rowIdentity) {
     if (window.debug) {
-      window.debug.error("Missing cell metadata for update");
+      window.debug.error("Missing stable row identity for update");
+    }
+    if (typeof showError !== "undefined") {
+      showError(
+        "This row cannot be identified safely. Refresh the table before editing."
+      );
     }
     cancelCellEdit(cell);
     return;
@@ -2909,6 +2928,19 @@ function saveCellEdit(cell) {
   // Show saving state
   cell.classList.add("saving");
   cell.classList.remove("error");
+  const win = /** @type {any} */ (window);
+  win.__cellEditSequence = Number(win.__cellEditSequence || 0) + 1;
+  const requestId = `cell-edit-${Date.now()}-${win.__cellEditSequence}`;
+  cell.setAttribute("data-edit-request-id", requestId);
+  if (!(win.__pendingCellEdits instanceof Map)) {
+    win.__pendingCellEdits = new Map();
+  }
+  win.__pendingCellEdits.set(requestId, {
+    cell,
+    tableId,
+    localIndex,
+    columnIndex: parseInt(cell.getAttribute("data-column") || "", 10),
+  });
 
   // Send update request to backend
   if (window.vscode && typeof window.vscode.postMessage === "function") {
@@ -2916,7 +2948,8 @@ function saveCellEdit(cell) {
     window.vscode.postMessage({
       type: "updateCellData",
       tableName: tableName,
-      rowIndex: rowIndex,
+      requestId: requestId,
+      rowIdentity: rowIdentity,
       columnName: columnName,
       newValue: newValue,
       key: currentState.encryptionKey,
@@ -2929,6 +2962,30 @@ function saveCellEdit(cell) {
   }
 }
 
+function findPendingEditCell(requestId) {
+  if (!requestId) {
+    return null;
+  }
+  return Array.from(
+    document.querySelectorAll(".data-cell[data-edit-request-id]")
+  ).find(
+    (candidate) =>
+      candidate.getAttribute("data-edit-request-id") === requestId
+  );
+}
+
+function takePendingCellEdit(requestId) {
+  const win = /** @type {any} */ (window);
+  const pending =
+    win.__pendingCellEdits instanceof Map
+      ? win.__pendingCellEdits.get(requestId)
+      : null;
+  if (win.__pendingCellEdits instanceof Map) {
+    win.__pendingCellEdits.delete(requestId);
+  }
+  return pending || null;
+}
+
 /**
  * Cancel cell edit
  * @param {Element} cell - The cell element being edited
@@ -2938,7 +2995,13 @@ function cancelCellEdit(cell) {
     return;
   }
 
+  const requestId = cell.getAttribute("data-edit-request-id");
+  const win = /** @type {any} */ (window);
+  if (requestId && win.__pendingCellEdits instanceof Map) {
+    win.__pendingCellEdits.delete(requestId);
+  }
   cell.classList.remove("editing", "saving", "error");
+  cell.removeAttribute("data-edit-request-id");
   const input = cell.querySelector(".cell-input");
   if (input) {
     /** @type {HTMLInputElement} */ (input).value = "";
@@ -2950,18 +3013,60 @@ function cancelCellEdit(cell) {
  * @param {Object} message - Success message from backend
  */
 function handleCellUpdateSuccess(message) {
-  const { tableName, rowIndex, columnName, newValue } = message;
+  const { requestId, newValue, rowIdentity } = message;
 
-  // Find the cell that was updated
-  const cell = document.querySelector(
-    `.data-cell[data-row-index="${rowIndex}"][data-column-name="${columnName}"]`
-  );
+  const pending = takePendingCellEdit(requestId);
+  const cell = pending?.cell || findPendingEditCell(requestId);
+  const tableId = pending?.tableId || cell?.closest(".enhanced-table-wrapper")?.getAttribute("data-table-id") || "";
+  const localIndex = Number.isInteger(pending?.localIndex)
+    ? pending.localIndex
+    : parseInt(
+        cell?.closest("tr[data-local-index]")?.getAttribute("data-local-index") || "",
+        10
+      );
+  const columnIndex = Number.isInteger(pending?.columnIndex)
+    ? pending.columnIndex
+    : parseInt(cell?.getAttribute("data-column") || "", 10);
+  const wrapper = Array.from(
+    document.querySelectorAll(".enhanced-table-wrapper[data-table-id]")
+  ).find(candidate => candidate.getAttribute("data-table-id") === tableId);
+  const tableStash = /** @type {any} */ (window).__tableDataStash;
+  const stashedTable =
+    tableId && tableStash instanceof Map ? tableStash.get(tableId) : null;
+  if (
+    rowIdentity &&
+    stashedTable &&
+    Array.isArray(stashedTable.rowIdentities) &&
+    Number.isInteger(localIndex)
+  ) {
+    stashedTable.rowIdentities[localIndex] = rowIdentity;
+  }
+  if (
+    stashedTable &&
+    Array.isArray(stashedTable.pageData) &&
+    Array.isArray(stashedTable.pageData[localIndex]) &&
+    Number.isInteger(columnIndex)
+  ) {
+    stashedTable.pageData[localIndex][columnIndex] = newValue;
+  }
+  const virtualState = /** @type {any} */ (wrapper)?.__virtualTableState;
+  if (
+    virtualState &&
+    Array.isArray(virtualState.pageData) &&
+    Array.isArray(virtualState.pageData[localIndex]) &&
+    Number.isInteger(columnIndex)
+  ) {
+    virtualState.pageData[localIndex][columnIndex] = newValue;
+  }
 
-  if (cell) {
+  if (cell && cell.isConnected) {
     // Update the cell content
     const cellContent = cell.querySelector(".cell-content");
     if (cellContent) {
-      cellContent.setAttribute("data-original-value", newValue || "");
+      cellContent.setAttribute(
+        "data-original-value",
+        newValue === null || newValue === undefined ? "" : String(newValue)
+      );
 
       if (newValue === null || newValue === "") {
         cellContent.innerHTML = "<em>NULL</em>";
@@ -2972,12 +3077,21 @@ function handleCellUpdateSuccess(message) {
 
     // Remove editing state
     cell.classList.remove("editing", "saving", "error");
+    cell.removeAttribute("data-edit-request-id");
 
     // Show success feedback
     cell.style.backgroundColor = "var(--vscode-list-activeSelectionBackground)";
     setTimeout(() => {
       cell.style.backgroundColor = "";
     }, 1000);
+  }
+
+  if (
+    virtualState &&
+    wrapper &&
+    typeof window.refreshVirtualTable === "function"
+  ) {
+    window.refreshVirtualTable(wrapper);
   }
 
   if (typeof showSuccess !== "undefined") {
@@ -2990,16 +3104,16 @@ function handleCellUpdateSuccess(message) {
  * @param {Object} message - Error message from backend
  */
 function handleCellUpdateError(message) {
-  const { tableName, rowIndex, columnName } = message;
+  const { requestId } = message;
 
   // Find the cell that failed to update
-  const cell = document.querySelector(
-    `.data-cell[data-row-index="${rowIndex}"][data-column-name="${columnName}"]`
-  );
+  const pending = takePendingCellEdit(requestId);
+  const cell = pending?.cell || findPendingEditCell(requestId);
 
-  if (cell) {
+  if (cell && cell.isConnected) {
     cell.classList.remove("saving");
     cell.classList.add("error");
+    cell.removeAttribute("data-edit-request-id");
 
     // Keep editing mode active so user can retry
     setTimeout(() => {

--- a/media/table.js
+++ b/media/table.js
@@ -740,7 +740,7 @@ function renderTableCellHtml(
   let cellContentHtml = "";
   if (cell === null || cell === undefined) {
     cellContentHtml =
-      '<div class="cell-content" data-original-value=""><em>NULL</em></div>';
+      '<div class="cell-content" data-original-value="" data-original-is-null="true"><em>NULL</em></div>';
   } else if (isBlob && blobBytes) {
     const sizeText = formatBytes(blobBytes.length);
     const mime = detectImageMime(blobBytes);
@@ -775,7 +775,7 @@ function renderTableCellHtml(
       raw.length > CELL_ORIGINAL_LIMIT ? ' data-original-truncated="true"' : "";
     cellContentHtml = `<div class="cell-content" data-original-value="${escapeHtmlFast(
       original
-    )}"${truncatedAttr}>${escapeHtmlFast(display)}</div>`;
+    )}" data-original-is-null="false"${truncatedAttr}>${escapeHtmlFast(display)}</div>`;
   }
 
   const cellEditable = isEditable && !isBlob;

--- a/media/table.js
+++ b/media/table.js
@@ -326,6 +326,8 @@ function createDataTable(data, columns, tableName = "", options = {}) {
     isQueryResult = false, // Whether this is a query result
     query = null, // Original SQL query for result tabs
     allowEditing = null, // Override editing permission
+    rowIdentities = [], // Stable database identities aligned with source rows
+    editError = "", // Explanation shown when safe editing is unavailable
   } = options;
 
   // Create foreign key lookup map
@@ -423,6 +425,7 @@ function createDataTable(data, columns, tableName = "", options = {}) {
     columns,
     startIndex,
     tableName,
+    rowIdentities,
   });
 
   if (virtualize) {
@@ -439,6 +442,7 @@ function createDataTable(data, columns, tableName = "", options = {}) {
         foreignKeyMap,
         options,
         tableName,
+        rowIdentities,
       });
     } catch (_) {
       // ignore stashing errors (best-effort)
@@ -480,7 +484,11 @@ function createDataTable(data, columns, tableName = "", options = {}) {
             isQueryResult
               ? `<span class="table-readonly-indicator" title="Query results are read-only">🧮 Query Result</span>`
               : !isEditable
-              ? `<span class="table-readonly-indicator" title="Table is read-only">🔒 Read-only</span>`
+              ? `<span class="table-readonly-indicator" title="${escapeHtmlFast(
+                  editError || "Table is read-only"
+                )}">🔒 ${
+                  editError ? "Read-only: no safe row identity" : "Read-only"
+                }</span>`
               : ``
           }
           ${

--- a/media/table.js
+++ b/media/table.js
@@ -486,9 +486,7 @@ function createDataTable(data, columns, tableName = "", options = {}) {
               : !isEditable
               ? `<span class="table-readonly-indicator" title="${escapeHtmlFast(
                   editError || "Table is read-only"
-                )}">🔒 ${
-                  editError ? "Read-only: no safe row identity" : "Read-only"
-                }</span>`
+                )}">🔒 Read-only</span>`
               : ``
           }
           ${

--- a/src/databaseEditorProvider.ts
+++ b/src/databaseEditorProvider.ts
@@ -634,9 +634,16 @@ export class DatabaseEditorProvider implements vscode.CustomReadonlyEditorProvid
         }
     }
 
-    private async handleTableDataRequest(webviewPanel: vscode.WebviewPanel, databasePath: string, tableName: string, key?: string, page?: number, pageSize?: number, setSync: boolean = true) {
+    private async handleTableDataRequest(webviewPanel: vscode.WebviewPanel, databasePath: string, tableName: string, key?: string, page?: number, pageSize?: number, setSync: boolean = true, syncToken?: TableSyncState) {
+        const syncIsCurrent = () => !syncToken || this.lastSync.get(databasePath) === syncToken;
         try {
+            if (!syncIsCurrent()) {
+                return;
+            }
             const dbService = await this.getOrCreateConnection(databasePath, key);
+            if (!syncIsCurrent()) {
+                return;
+            }
             
             // Use pagination if provided, otherwise use default behavior
             let result;
@@ -657,6 +664,9 @@ export class DatabaseEditorProvider implements vscode.CustomReadonlyEditorProvid
                     totalRowsKnown = false;
                     // Compute count in background and update UI when ready
                     dbService.getRowCount(tableName).then(count => {
+                        if (!syncIsCurrent()) {
+                            return;
+                        }
                         this.rowCountCache.set(cacheKey, count);
                         this.postWebviewMessage(webviewPanel.webview, {
                             type: 'tableRowCount',
@@ -674,6 +684,9 @@ export class DatabaseEditorProvider implements vscode.CustomReadonlyEditorProvid
                 totalRowCount = result.values.length;
                 totalRowsKnown = true;
             }
+            if (!syncIsCurrent()) {
+                return;
+            }
 
             // Get foreign key information for the table
             const metaKey = `${databasePath}:${tableName}`;
@@ -681,6 +694,9 @@ export class DatabaseEditorProvider implements vscode.CustomReadonlyEditorProvid
             if (foreignKeys.length === 0) {
                 try {
                     foreignKeys = await dbService.getForeignKeys(tableName);
+                    if (!syncIsCurrent()) {
+                        return;
+                    }
                     this.foreignKeysCache.set(metaKey, foreignKeys);
                 } catch (err) {
                     this.debugWarn('getForeignKeys', `Failed to fetch foreign keys for ${tableName}:`, err);
@@ -694,6 +710,9 @@ export class DatabaseEditorProvider implements vscode.CustomReadonlyEditorProvid
             if (!columnInfo) {
                 // Fill in background; UI doesn't need this to render the page.
                 dbService.getTableInfo(tableName).then(info => {
+                    if (!syncIsCurrent()) {
+                        return;
+                    }
                     this.tableInfoCache.set(metaKey, info as any[]);
                     this.postWebviewMessage(webviewPanel.webview, {
                         type: 'tableColumnInfo',
@@ -705,6 +724,9 @@ export class DatabaseEditorProvider implements vscode.CustomReadonlyEditorProvid
                 });
             }
 
+            if (!syncIsCurrent()) {
+                return;
+            }
             this.postWebviewMessage(webviewPanel.webview, {
                 type: 'tableData',
                 success: true,
@@ -723,14 +745,15 @@ export class DatabaseEditorProvider implements vscode.CustomReadonlyEditorProvid
             });
             // cache this page for future diffs ONLY if this is a user-initiated load
             if (setSync) {
-                this.lastSync.set(databasePath, {
+                const nextSync = syncToken || {
                     table: tableName!,
                     since: '',
                     page: page!,
                     pageSize: pageSize!,
-                    key,
-                    lastPageData: result.values // <--- store the actual rows
-                });
+                    key
+                };
+                nextSync.lastPageData = result.values;
+                this.lastSync.set(databasePath, nextSync);
                 this.debugLog('getTableDataPaginated', 'lastSync set for', databasePath, {
                     table: tableName,
                     page,
@@ -739,6 +762,9 @@ export class DatabaseEditorProvider implements vscode.CustomReadonlyEditorProvid
                 });
             }
         } catch (error) {
+            if (!syncIsCurrent()) {
+                return;
+            }
             this.postWebviewMessage(webviewPanel.webview, {
                 type: 'error',
                 message: `Failed to load table data: ${error}`
@@ -775,7 +801,8 @@ export class DatabaseEditorProvider implements vscode.CustomReadonlyEditorProvid
                     key,
                     sync.page,
                     sync.pageSize,
-                    true
+                    true,
+                    sync
                 );
             }
         } catch (error) {

--- a/src/databaseEditorProvider.ts
+++ b/src/databaseEditorProvider.ts
@@ -6,12 +6,21 @@ import { DatabaseWatcher } from './databaseWatcher';
 import type { ExtensionToWebviewMessage, WebviewSettingsPayload } from './webviewMessages';
 import { isWebviewToExtensionMessage } from './webviewMessages';
 
+interface TableSyncState {
+    table: string;
+    since: string;
+    page: number;
+    pageSize: number;
+    key?: string;
+    lastPageData?: any[][];
+}
+
 export class DatabaseEditorProvider implements vscode.CustomReadonlyEditorProvider {
     public static readonly viewType = 'sqlite-intelliview-vscode.databaseEditor';
     private static activeProvider: DatabaseEditorProvider | undefined;
     private activeConnections: Map<string, DatabaseService> = new Map();
     /** Track last sync state per database for delta updates */
-    private lastSync: Map<string, { table: string; since: string; page: number; pageSize: number; key?: string; lastPageData?: any[][] }> = new Map();
+    private lastSync: Map<string, TableSyncState> = new Map();
     private databaseWatcher: DatabaseWatcher = new DatabaseWatcher();
     private webviewPanels: Map<string, vscode.WebviewPanel> = new Map();
     /** cache full pages keyed by `${db}:${table}:${page}:${pageSize}` → QueryResult.values */
@@ -206,7 +215,7 @@ export class DatabaseEditorProvider implements vscode.CustomReadonlyEditorProvid
                 return;
             }
 
-            this.debugLog('onDidReceiveMessage', `Received message type: ${e.type}`, e);
+            this.debugLog('onDidReceiveMessage', `Received message type: ${e.type}`);
             
             switch (e.type) {
                 case 'requestDatabaseInfo':
@@ -722,7 +731,12 @@ export class DatabaseEditorProvider implements vscode.CustomReadonlyEditorProvid
                     key,
                     lastPageData: result.values // <--- store the actual rows
                 });
-                this.debugLog('getTableDataPaginated', 'lastSync set for', databasePath, { table: tableName, page, pageSize, lastPageData: result.values });
+                this.debugLog('getTableDataPaginated', 'lastSync set for', databasePath, {
+                    table: tableName,
+                    page,
+                    pageSize,
+                    rowCount: result.values.length
+                });
             }
         } catch (error) {
             this.postWebviewMessage(webviewPanel.webview, {
@@ -732,7 +746,7 @@ export class DatabaseEditorProvider implements vscode.CustomReadonlyEditorProvid
         }
     }
 
-    private async handleCellUpdateRequest(webviewPanel: vscode.WebviewPanel, databasePath: string, tableName: string, requestId: string, rowIdentity: RowIdentity, columnName: string, newValue: any, key?: string) {
+    private async handleCellUpdateRequest(webviewPanel: vscode.WebviewPanel, databasePath: string, tableName: string, requestId: string, rowIdentity: RowIdentity, columnName: string, newValue: unknown, key?: string) {
         try {
             const dbService = await this.getOrCreateConnection(databasePath, key);
             const updateResult = await dbService.updateCellData(tableName, rowIdentity, columnName, newValue);
@@ -1089,50 +1103,71 @@ export class DatabaseEditorProvider implements vscode.CustomReadonlyEditorProvid
     }
 
     public async handleExternalDatabaseChange(databasePath: string) {
-        // External changes can modify data and schema; clear all cached metadata/counts for this DB.
-        this.invalidateCachesForDatabase(databasePath);
+        let panel: vscode.WebviewPanel | undefined;
+        let sync: TableSyncState | undefined;
 
-        this.closeConnection(databasePath);
-        const panel = this.webviewPanels.get(databasePath);
-        const sync = this.lastSync.get(databasePath);
-        this.debugLog('DatabaseChange', `[handleExternalDatabaseChange] Triggered for ${databasePath}`, { hasPanel: !!panel, hasSync: !!sync });
-        if (!panel || !sync) {
-            this.debugWarn('DatabaseChange', `[handleExternalDatabaseChange] No panel or sync found for ${databasePath}`, { hasPanel: !!panel, hasSync: !!sync });
-            return;
+        try {
+            panel = this.webviewPanels.get(databasePath);
+            sync = this.lastSync.get(databasePath);
+            // External changes can modify data and schema; clear all cached metadata/counts for this DB.
+            this.invalidateCachesForDatabase(databasePath);
+            this.closeConnection(databasePath);
+            this.debugLog('DatabaseChange', `[handleExternalDatabaseChange] Triggered for ${databasePath}`, { hasPanel: !!panel, hasSync: !!sync });
+            if (!panel || !sync) {
+                this.debugWarn('DatabaseChange', `[handleExternalDatabaseChange] No panel or sync found for ${databasePath}`, { hasPanel: !!panel, hasSync: !!sync });
+                return;
+            }
+
+            const { table, page, pageSize, key } = sync;
+            this.debugLog('DatabaseChange', '[handleExternalDatabaseChange] Using sync state', { table, page, pageSize });
+            const db = await this.getOrCreateConnection(databasePath, key);
+            const newResult = await db.getTableDataPaginated(table, page, pageSize);
+            const newTotalCount = await db.getRowCount(table);
+            this.rowCountCache.set(this.getTableCacheKey(databasePath, table), newTotalCount);
+            this.debugLog('DatabaseChange', 'New page data fetched', { rowCount: newResult.values.length, newTotalCount });
+            const [foreignKeys, columnInfo] = await Promise.all([
+                db.getForeignKeys(table),
+                db.getTableInfo(table)
+            ]);
+            await this.postWebviewMessage(panel.webview, {
+                type: 'tableData',
+                success: true,
+                tableName: table,
+                data: newResult.values,
+                columns: newResult.columns,
+                rowIdentities: newResult.rowIdentities,
+                editable: newResult.editable,
+                editError: newResult.editError,
+                foreignKeys,
+                columnInfo,
+                page,
+                pageSize,
+                totalRows: newTotalCount,
+                totalRowsKnown: true
+            });
+            sync.lastPageData = newResult.values;
+            this.lastSync.set(databasePath, sync);
+            this.debugLog('DatabaseChange', 'lastPageData updated in lastSync', {
+                databasePath,
+                rowCount: sync.lastPageData.length
+            });
+        } catch (error) {
+            if (sync) {
+                sync.lastPageData = undefined;
+                this.lastSync.set(databasePath, sync);
+            }
+            this.debugError('DatabaseChange', `Failed to refresh ${databasePath}:`, error);
+            if (panel) {
+                try {
+                    await this.postWebviewMessage(panel.webview, {
+                        type: 'error',
+                        message: `Failed to refresh database: ${error}`
+                    });
+                } catch (notificationError) {
+                    this.debugWarn('DatabaseChange', 'Failed to notify webview about refresh failure:', notificationError);
+                }
+            }
         }
-        const { table, page, pageSize, key } = sync;
-        this.debugLog('DatabaseChange', '[handleExternalDatabaseChange] Using sync state', { table, page, pageSize });
-        const db = await this.getOrCreateConnection(databasePath, key);
-        const newResult = await db.getTableDataPaginated(table, page, pageSize);
-        const newTotalCount = await db.getRowCount(table);
-        this.rowCountCache.set(this.getTableCacheKey(databasePath, table), newTotalCount);
-        this.debugLog('DatabaseChange', 'New page data fetched', { rowCount: newResult.values.length, newTotalCount });
-        const [foreignKeys, columnInfo] = await Promise.all([
-            db.getForeignKeys(table),
-            db.getTableInfo(table)
-        ]);
-        this.postWebviewMessage(panel.webview, {
-            type: 'tableData',
-            success: true,
-            tableName: table,
-            data: newResult.values,
-            columns: newResult.columns,
-            rowIdentities: newResult.rowIdentities,
-            editable: newResult.editable,
-            editError: newResult.editError,
-            foreignKeys,
-            columnInfo,
-            page,
-            pageSize,
-            totalRows: newTotalCount,
-            totalRowsKnown: true
-        });
-        sync.lastPageData = newResult.values;
-        this.lastSync.set(databasePath, sync);
-        this.debugLog('DatabaseChange', 'lastPageData updated in lastSync', {
-            databasePath,
-            rowCount: sync.lastPageData.length
-        });
     }
 }
 

--- a/src/databaseEditorProvider.ts
+++ b/src/databaseEditorProvider.ts
@@ -11,7 +11,7 @@ export class DatabaseEditorProvider implements vscode.CustomReadonlyEditorProvid
     private static activeProvider: DatabaseEditorProvider | undefined;
     private activeConnections: Map<string, DatabaseService> = new Map();
     /** Track last sync state per database for delta updates */
-    private lastSync: Map<string, { table: string; since: string; page: number; pageSize: number; lastPageData?: any[][] }> = new Map();
+    private lastSync: Map<string, { table: string; since: string; page: number; pageSize: number; key?: string; lastPageData?: any[][] }> = new Map();
     private databaseWatcher: DatabaseWatcher = new DatabaseWatcher();
     private webviewPanels: Map<string, vscode.WebviewPanel> = new Map();
     /** cache full pages keyed by `${db}:${table}:${page}:${pageSize}` → QueryResult.values */
@@ -719,6 +719,7 @@ export class DatabaseEditorProvider implements vscode.CustomReadonlyEditorProvid
                     since: '',
                     page: page!,
                     pageSize: pageSize!,
+                    key,
                     lastPageData: result.values // <--- store the actual rows
                 });
                 this.debugLog('getTableDataPaginated', 'lastSync set for', databasePath, { table: tableName, page, pageSize, lastPageData: result.values });
@@ -1078,9 +1079,6 @@ export class DatabaseEditorProvider implements vscode.CustomReadonlyEditorProvid
 
     private debugLogConnections(): void {
         this.debugLog('Connection', `Active connections (${this.activeConnections.size})`);
-        for (const [key] of this.activeConnections) {
-            this.debugLog('Connection', `Connection Key ${key}`);
-        }
     }
 
     // Add a global cleanup method for extension deactivation
@@ -1099,12 +1097,12 @@ export class DatabaseEditorProvider implements vscode.CustomReadonlyEditorProvid
         const sync = this.lastSync.get(databasePath);
         this.debugLog('DatabaseChange', `[handleExternalDatabaseChange] Triggered for ${databasePath}`, { hasPanel: !!panel, hasSync: !!sync });
         if (!panel || !sync) {
-            this.debugWarn('DatabaseChange', `[handleExternalDatabaseChange] No panel or sync found for ${databasePath}`, { panel, sync });
+            this.debugWarn('DatabaseChange', `[handleExternalDatabaseChange] No panel or sync found for ${databasePath}`, { hasPanel: !!panel, hasSync: !!sync });
             return;
         }
-        const { table, page, pageSize } = sync;
+        const { table, page, pageSize, key } = sync;
         this.debugLog('DatabaseChange', '[handleExternalDatabaseChange] Using sync state', { table, page, pageSize });
-        const db = await this.getOrCreateConnection(databasePath);
+        const db = await this.getOrCreateConnection(databasePath, key);
         const newResult = await db.getTableDataPaginated(table, page, pageSize);
         const newTotalCount = await db.getRowCount(table);
         this.rowCountCache.set(this.getTableCacheKey(databasePath, table), newTotalCount);

--- a/src/databaseEditorProvider.ts
+++ b/src/databaseEditorProvider.ts
@@ -1123,12 +1123,16 @@ export class DatabaseEditorProvider implements vscode.CustomReadonlyEditorProvid
             const db = await this.getOrCreateConnection(databasePath, key);
             const newResult = await db.getTableDataPaginated(table, page, pageSize);
             const newTotalCount = await db.getRowCount(table);
-            this.rowCountCache.set(this.getTableCacheKey(databasePath, table), newTotalCount);
-            this.debugLog('DatabaseChange', 'New page data fetched', { rowCount: newResult.values.length, newTotalCount });
             const [foreignKeys, columnInfo] = await Promise.all([
                 db.getForeignKeys(table),
                 db.getTableInfo(table)
             ]);
+            if (this.lastSync.get(databasePath) !== sync) {
+                this.debugLog('DatabaseChange', `Discarding stale refresh result for ${databasePath}`);
+                return;
+            }
+            this.rowCountCache.set(this.getTableCacheKey(databasePath, table), newTotalCount);
+            this.debugLog('DatabaseChange', 'New page data fetched', { rowCount: newResult.values.length, newTotalCount });
             await this.postWebviewMessage(panel.webview, {
                 type: 'tableData',
                 success: true,
@@ -1145,6 +1149,10 @@ export class DatabaseEditorProvider implements vscode.CustomReadonlyEditorProvid
                 totalRows: newTotalCount,
                 totalRowsKnown: true
             });
+            if (this.lastSync.get(databasePath) !== sync) {
+                this.debugLog('DatabaseChange', `Discarding stale refresh state for ${databasePath}`);
+                return;
+            }
             sync.lastPageData = newResult.values;
             this.lastSync.set(databasePath, sync);
             this.debugLog('DatabaseChange', 'lastPageData updated in lastSync', {
@@ -1152,12 +1160,13 @@ export class DatabaseEditorProvider implements vscode.CustomReadonlyEditorProvid
                 rowCount: sync.lastPageData.length
             });
         } catch (error) {
-            if (sync) {
+            const syncIsCurrent = sync && this.lastSync.get(databasePath) === sync;
+            if (sync && syncIsCurrent) {
                 sync.lastPageData = undefined;
                 this.lastSync.set(databasePath, sync);
             }
             this.debugError('DatabaseChange', `Failed to refresh ${databasePath}:`, error);
-            if (panel) {
+            if (panel && syncIsCurrent) {
                 try {
                     await this.postWebviewMessage(panel.webview, {
                         type: 'error',

--- a/src/databaseEditorProvider.ts
+++ b/src/databaseEditorProvider.ts
@@ -635,7 +635,17 @@ export class DatabaseEditorProvider implements vscode.CustomReadonlyEditorProvid
     }
 
     private async handleTableDataRequest(webviewPanel: vscode.WebviewPanel, databasePath: string, tableName: string, key?: string, page?: number, pageSize?: number, setSync: boolean = true, syncToken?: TableSyncState) {
-        const syncIsCurrent = () => !syncToken || this.lastSync.get(databasePath) === syncToken;
+        const requestToken = syncToken || {
+            table: tableName,
+            since: '',
+            page: page ?? 1,
+            pageSize: pageSize ?? 1000,
+            key
+        };
+        if (!syncToken) {
+            this.lastSync.set(databasePath, requestToken);
+        }
+        const syncIsCurrent = () => this.lastSync.get(databasePath) === requestToken;
         try {
             if (!syncIsCurrent()) {
                 return;
@@ -745,15 +755,8 @@ export class DatabaseEditorProvider implements vscode.CustomReadonlyEditorProvid
             });
             // cache this page for future diffs ONLY if this is a user-initiated load
             if (setSync) {
-                const nextSync = syncToken || {
-                    table: tableName!,
-                    since: '',
-                    page: page!,
-                    pageSize: pageSize!,
-                    key
-                };
-                nextSync.lastPageData = result.values;
-                this.lastSync.set(databasePath, nextSync);
+                requestToken.lastPageData = result.values;
+                this.lastSync.set(databasePath, requestToken);
                 this.debugLog('getTableDataPaginated', 'lastSync set for', databasePath, {
                     table: tableName,
                     page,

--- a/src/databaseEditorProvider.ts
+++ b/src/databaseEditorProvider.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
-import { DatabaseService } from './databaseService';
+import { DatabaseService, RowIdentity } from './databaseService';
 import { DatabaseWatcher } from './databaseWatcher';
 import type { ExtensionToWebviewMessage, WebviewSettingsPayload } from './webviewMessages';
 import { isWebviewToExtensionMessage } from './webviewMessages';
@@ -236,7 +236,7 @@ export class DatabaseEditorProvider implements vscode.CustomReadonlyEditorProvid
                     this.handleTableDataRequest(webviewPanel, document.uri.fsPath, e.tableName, e.key, e.page, e.pageSize, true);
                     return;
                 case 'updateCellData':
-                    this.handleCellUpdateRequest(webviewPanel, document.uri.fsPath, e.tableName, e.rowIndex, e.columnName, e.newValue, e.key);
+                    this.handleCellUpdateRequest(webviewPanel, document.uri.fsPath, e.tableName, e.requestId, e.rowIdentity, e.columnName, e.newValue, e.key);
                     return;
                 case 'deleteRow':
                     this.debugLog('onDidReceiveMessage', 'Processing deleteRow message');
@@ -696,29 +696,15 @@ export class DatabaseEditorProvider implements vscode.CustomReadonlyEditorProvid
                 });
             }
 
-            // Fix column headers: alias rowid as _rowid and remove duplicate id columns
-            let columns = result.columns;
-            let data = result.values;
-            // If first column is rowid and second is id, remove the second if they are identical for all rows
-            if (columns.length > 1 && columns[0].toLowerCase() === 'rowid' && columns[1].toLowerCase() === 'id') {
-                const allMatch = data.every(row => row[0] === row[1]);
-                if (allMatch) {
-                    // Remove the second column (id)
-                    columns = [columns[0], ...columns.slice(2)];
-                    data = data.map(row => [row[0], ...row.slice(2)]);
-                }
-            }
-            // Always alias rowid as _rowid for clarity
-            if (columns[0].toLowerCase() === 'rowid') {
-                columns = ['_rowid', ...columns.slice(1)];
-            }
-
             this.postWebviewMessage(webviewPanel.webview, {
                 type: 'tableData',
                 success: true,
                 tableName,
-                data: data,
-                columns: columns,
+                data: result.values,
+                columns: result.columns,
+                rowIdentities: result.rowIdentities,
+                editable: result.editable,
+                editError: result.editError,
                 foreignKeys: foreignKeys,
                 columnInfo: columnInfo,
                 page: page,
@@ -733,9 +719,9 @@ export class DatabaseEditorProvider implements vscode.CustomReadonlyEditorProvid
                     since: '',
                     page: page!,
                     pageSize: pageSize!,
-                    lastPageData: data // <--- store the actual rows
+                    lastPageData: result.values // <--- store the actual rows
                 });
-                this.debugLog('getTableDataPaginated', 'lastSync set for', databasePath, { table: tableName, page, pageSize, lastPageData: data });
+                this.debugLog('getTableDataPaginated', 'lastSync set for', databasePath, { table: tableName, page, pageSize, lastPageData: result.values });
             }
         } catch (error) {
             this.postWebviewMessage(webviewPanel.webview, {
@@ -745,20 +731,10 @@ export class DatabaseEditorProvider implements vscode.CustomReadonlyEditorProvid
         }
     }
 
-    private async handleCellUpdateRequest(webviewPanel: vscode.WebviewPanel, databasePath: string, tableName: string, rowIndex: number, columnName: string, newValue: any, key?: string) {
-        this.debugLog('handleCellUpdateRequest', `Processing cell update request:`, {
-            tableName, rowIndex, columnName, newValue,
-            databasePath: databasePath.substring(databasePath.lastIndexOf('/') + 1)
-        });
-
+    private async handleCellUpdateRequest(webviewPanel: vscode.WebviewPanel, databasePath: string, tableName: string, requestId: string, rowIdentity: RowIdentity, columnName: string, newValue: any, key?: string) {
         try {
             const dbService = await this.getOrCreateConnection(databasePath, key);
-            // First, get the rowid for the row we want to update
-            this.debugLog('handleCellUpdateRequest', `Getting rowid for row index ${rowIndex}`);
-            const rowId = await dbService.getCellRowId(tableName, rowIndex);
-            // Update the cell data
-            this.debugLog('handleCellUpdateRequest', `Updating cell data with rowid ${rowId}`);
-            await dbService.updateCellData(tableName, rowId, columnName, newValue);
+            const updateResult = await dbService.updateCellData(tableName, rowIdentity, columnName, newValue);
 
             // Invalidate caches for this table so subsequent reads are fresh.
             this.invalidateCachesForTable(databasePath, tableName);
@@ -768,12 +744,25 @@ export class DatabaseEditorProvider implements vscode.CustomReadonlyEditorProvid
                 type: 'cellUpdateSuccess',
                 success: true,
                 tableName: tableName,
-                rowIndex: rowIndex,
+                requestId,
                 columnName: columnName,
-                newValue: newValue
+                newValue: updateResult.value,
+                rowIdentity: updateResult.identity,
+                changes: updateResult.changes
             });
-            
-            this.debugLog('handleCellUpdateRequest', 'Cell update completed successfully');
+
+            const sync = this.lastSync.get(databasePath);
+            if (sync?.table === tableName) {
+                await this.handleTableDataRequest(
+                    webviewPanel,
+                    databasePath,
+                    tableName,
+                    key,
+                    sync.page,
+                    sync.pageSize,
+                    true
+                );
+            }
         } catch (error) {
             this.debugError('handleCellUpdateRequest', 'Cell update failed:', error);
             this.postWebviewMessage(webviewPanel.webview, {
@@ -781,7 +770,7 @@ export class DatabaseEditorProvider implements vscode.CustomReadonlyEditorProvid
                 success: false,
                 message: `Failed to update cell: ${error}`,
                 tableName: tableName,
-                rowIndex: rowIndex,
+                requestId,
                 columnName: columnName
             });
         }
@@ -1113,66 +1102,34 @@ export class DatabaseEditorProvider implements vscode.CustomReadonlyEditorProvid
             this.debugWarn('DatabaseChange', `[handleExternalDatabaseChange] No panel or sync found for ${databasePath}`, { panel, sync });
             return;
         }
-        const { table, page, pageSize, lastPageData } = sync;
+        const { table, page, pageSize } = sync;
         this.debugLog('DatabaseChange', '[handleExternalDatabaseChange] Using sync state', { table, page, pageSize });
         const db = await this.getOrCreateConnection(databasePath);
         const newResult = await db.getTableDataPaginated(table, page, pageSize);
         const newTotalCount = await db.getRowCount(table);
         this.rowCountCache.set(this.getTableCacheKey(databasePath, table), newTotalCount);
         this.debugLog('DatabaseChange', 'New page data fetched', { rowCount: newResult.values.length, newTotalCount });
-        const oldRows = lastPageData || [];
-        const newRows = newResult.values;
-        const baseIndex = (page - 1) * pageSize;
-        const oldMap = new Map();
-        oldRows.forEach((r, i) => oldMap.set(r[0], JSON.stringify(r)));
-        const newMap = new Map();
-        newRows.forEach((r, i) => newMap.set(r[0], JSON.stringify(r)));
-        const deletes: number[] = [];
-        for (const [rowid, _] of oldMap) {
-            if (!newMap.has(rowid)) {
-                const localIdx = oldRows.findIndex(r => r[0] === rowid);
-                deletes.push(baseIndex + localIdx);
-            }
-        }
-        const inserts: { rowIndex: number; rowData: any[] }[] = [];
-        newRows.forEach((r, i) => {
-            if (!oldMap.has(r[0])) {
-                inserts.push({ rowIndex: baseIndex + i, rowData: r });
-            }
-        });
-        const updates: { rowIndex: number; rowData: any[] }[] = [];
-        newRows.forEach((r, i) => {
-            const rowid = r[0], payload = JSON.stringify(r);
-            if (oldMap.has(rowid) && oldMap.get(rowid) !== payload) {
-                updates.push({ rowIndex: baseIndex + i, rowData: r });
-            }
-        });
-        const hasDelta = inserts.length > 0 || updates.length > 0 || deletes.length > 0;
-        this.debugLog('DatabaseChange', 'Delta computed', {
-            inserts: inserts.length,
-            updates: updates.length,
-            deletes: deletes.length
-        });
-        if (hasDelta) {
-            this.debugLog('DatabaseChange', 'Old Rows', JSON.stringify(oldRows));
-            this.debugLog('DatabaseChange', 'New Rows', JSON.stringify(newRows));
-        }
+        const [foreignKeys, columnInfo] = await Promise.all([
+            db.getForeignKeys(table),
+            db.getTableInfo(table)
+        ]);
         this.postWebviewMessage(panel.webview, {
-            type: 'tableDataDelta',
+            type: 'tableData',
+            success: true,
             tableName: table,
-            inserts,
-            updates,
-            deletes,
-            totalCount: newTotalCount
+            data: newResult.values,
+            columns: newResult.columns,
+            rowIdentities: newResult.rowIdentities,
+            editable: newResult.editable,
+            editError: newResult.editError,
+            foreignKeys,
+            columnInfo,
+            page,
+            pageSize,
+            totalRows: newTotalCount,
+            totalRowsKnown: true
         });
-        this.debugLog('DatabaseChange', 'tableDataDelta sent to webview', {
-            table,
-            inserts: inserts.length,
-            updates: updates.length,
-            deletes: deletes.length,
-            totalCount: newTotalCount
-        });
-        sync.lastPageData = newRows;
+        sync.lastPageData = newResult.values;
         this.lastSync.set(databasePath, sync);
         this.debugLog('DatabaseChange', 'lastPageData updated in lastSync', {
             databasePath,

--- a/src/databaseService.ts
+++ b/src/databaseService.ts
@@ -45,9 +45,16 @@ export interface QueryResult {
 
 export type SQLiteValue = number | string | Uint8Array | null;
 
+export interface SerializedBlobIdentityValue {
+    type: 'blob';
+    base64: string;
+}
+
+export type RowIdentityValue = SQLiteValue | SerializedBlobIdentityValue;
+
 export interface RowIdentityPart {
     column: string;
-    value: SQLiteValue;
+    value: RowIdentityValue;
 }
 
 export interface RowIdentity {
@@ -119,18 +126,35 @@ export class DatabaseService {
         return `"${identifier.replace(/"/g, '""')}"`;
     }
 
-    private serializeIdentityValue(value: unknown): SQLiteValue {
+    private serializeIdentityValue(value: unknown): RowIdentityValue {
         if (typeof value === 'bigint') {
             const numericValue = Number(value);
             return Number.isSafeInteger(numericValue) ? numericValue : value.toString();
         }
-        if (value === null || typeof value === 'string' || value instanceof Uint8Array) {
+        if (value instanceof Uint8Array) {
+            return { type: 'blob', base64: Buffer.from(value).toString('base64') };
+        }
+        if (value === null || typeof value === 'string') {
             return value;
         }
         if (typeof value === 'number' && Number.isFinite(value)) {
             return value;
         }
         throw new Error('Row identity contains an unsupported SQLite value.');
+    }
+
+    private deserializeIdentityValue(value: RowIdentityValue): SQLiteValue {
+        if (typeof value === 'object' && value !== null && !(value instanceof Uint8Array)) {
+            if (value.type !== 'blob' || typeof value.base64 !== 'string') {
+                throw new Error('Row identity contains an invalid serialized BLOB value.');
+            }
+            const decoded = Buffer.from(value.base64, 'base64');
+            if (decoded.toString('base64') !== value.base64) {
+                throw new Error('Row identity contains an invalid base64 BLOB value.');
+            }
+            return new Uint8Array(decoded);
+        }
+        return value;
     }
 
     private enqueueEdit<T>(operation: () => Promise<T>): Promise<T> {
@@ -759,7 +783,7 @@ export class DatabaseService {
             .map(column => `${this.quoteIdentifier(column)} IS ?`)
             .join(' AND ');
         const updateQuery = `UPDATE ${this.quoteIdentifier(tableName)} SET ${this.quoteIdentifier(columnName)} = ? WHERE ${whereClause}`;
-        const parameters = [processedValue, ...identity.parts.map(part => part.value)];
+        const parameters = [processedValue, ...identity.parts.map(part => this.deserializeIdentityValue(part.value))];
         let stmt: any = null;
         let transactionOpen = false;
         let committed = false;
@@ -793,7 +817,7 @@ export class DatabaseService {
                 kind: identity.kind,
                 parts: identity.parts.map(part => ({
                     column: part.column,
-                    value: part.column === columnName ? processedValue : part.value
+                    value: part.column === columnName ? this.serializeIdentityValue(processedValue) : part.value
                 }))
             };
 

--- a/src/databaseService.ts
+++ b/src/databaseService.ts
@@ -43,6 +43,38 @@ export interface QueryResult {
     values: any[][];
 }
 
+export interface RowIdentityPart {
+    column: string;
+    value: any;
+}
+
+export interface RowIdentity {
+    kind: 'primaryKey' | 'rowid';
+    parts: RowIdentityPart[];
+}
+
+export interface EditableTableData extends QueryResult {
+    rowIdentities: Array<RowIdentity | null>;
+    editable: boolean;
+    editError?: string;
+}
+
+export interface CellUpdateResult {
+    changes: number;
+    identity: RowIdentity;
+    value: any;
+}
+
+interface TableIdentityDefinition {
+    kind: 'primaryKey' | 'rowid';
+    columns: string[];
+}
+
+interface TableEditability {
+    definition: TableIdentityDefinition | null;
+    reason?: string;
+}
+
 /** 
  * A single change in a table since our last sync.
  */
@@ -472,76 +504,252 @@ export class DatabaseService {
         }
     }
 
-    async getTableData(tableName: string, limit: number = 1000, offset: number = 0): Promise<QueryResult> {
-        const query = `SELECT * FROM "${tableName}" LIMIT ${limit} OFFSET ${offset}`;
-        return this.executeQuery(query);
+    async getTableData(tableName: string, limit: number = 1000, offset: number = 0): Promise<EditableTableData> {
+        return this.getTableDataWithIdentities(tableName, limit, offset);
     }
 
-    public async getTableDataPaginated(tableName: string, page: number = 1, pageSize: number = 100): Promise<QueryResult> {
-        const offset = (page - 1) * pageSize;
-        const query = `SELECT * FROM "${tableName}" LIMIT ${pageSize} OFFSET ${offset}`;
-        return this.executeQuery(query);
+    public async getTableDataPaginated(tableName: string, page: number = 1, pageSize: number = 100): Promise<EditableTableData> {
+        const safePage = Number.isInteger(page) && page > 0 ? page : 1;
+        const safePageSize = Number.isInteger(pageSize) && pageSize > 0 ? pageSize : 100;
+        const offset = (safePage - 1) * safePageSize;
+        return this.getTableDataWithIdentities(tableName, safePageSize, offset);
     }
 
     async getRowCount(tableName: string): Promise<number> {
-        const result = await this.executeQuery(`SELECT COUNT(*) as count FROM "${tableName}"`);
+        const result = await this.executeQuery(`SELECT COUNT(*) as count FROM ${this.quoteIdentifier(tableName)}`);
         return result.values[0][0] as number;
     }
 
-    async updateCellData(tableName: string, rowId: any, columnName: string, newValue: any): Promise<void> {
+    private async getTableEditability(tableName: string): Promise<TableEditability> {
         if (!this.db) {
             throw new Error('Database not opened');
         }
 
-        this.debugLog('CellUpdate', 'Starting cell update:', {
-            tableName,
-            rowId,
-            columnName,
-            newValue,
-            newValueType: typeof newValue
+        const tableStmt = this.db.prepare(`
+            SELECT type, sql
+            FROM sqlite_master
+            WHERE name = ? AND type IN ('table', 'view')
+            LIMIT 1
+        `);
+        tableStmt.bind([tableName]);
+        const found = tableStmt.step();
+        const table = found ? tableStmt.getAsObject() : null;
+        tableStmt.free();
+
+        if (!table) {
+            return { definition: null, reason: `Table ${tableName} no longer exists.` };
+        }
+        if (table.type !== 'table') {
+            return { definition: null, reason: 'Views cannot be edited safely because they do not expose stable row identity.' };
+        }
+
+        const infoStmt = this.db.prepare(`PRAGMA table_info(${this.quoteIdentifier(tableName)})`);
+        const columns: Array<{ name: string; pkOrder: number }> = [];
+        while (infoStmt.step()) {
+            const row = infoStmt.getAsObject();
+            columns.push({
+                name: row.name as string,
+                pkOrder: Number(row.pk) || 0
+            });
+        }
+        infoStmt.free();
+
+        const primaryKeyColumns = columns
+            .filter(column => column.pkOrder > 0)
+            .sort((a, b) => a.pkOrder - b.pkOrder)
+            .map(column => column.name);
+        if (primaryKeyColumns.length > 0) {
+            return {
+                definition: {
+                    kind: 'primaryKey',
+                    columns: primaryKeyColumns
+                }
+            };
+        }
+
+        const createSql = typeof table.sql === 'string' ? table.sql : '';
+        if (/\bWITHOUT\s+ROWID\b/i.test(createSql)) {
+            return {
+                definition: null,
+                reason: 'This WITHOUT ROWID table has no declared primary key and cannot be edited safely.'
+            };
+        }
+
+        const declaredNames = new Set(columns.map(column => column.name.toLowerCase()));
+        const rowidAlias = ['rowid', '_rowid_', 'oid'].find(alias => !declaredNames.has(alias));
+        if (!rowidAlias) {
+            return {
+                definition: null,
+                reason: 'This table has no declared primary key and all SQLite rowid aliases are shadowed.'
+            };
+        }
+
+        return {
+            definition: {
+                kind: 'rowid',
+                columns: [rowidAlias]
+            }
+        };
+    }
+
+    private async getTableDataWithIdentities(tableName: string, limit: number, offset: number): Promise<EditableTableData> {
+        if (!this.db) {
+            throw new Error('Database not opened');
+        }
+
+        const safeLimit = Number.isInteger(limit) && limit > 0 ? limit : 1000;
+        const safeOffset = Number.isInteger(offset) && offset >= 0 ? offset : 0;
+        const editability = await this.getTableEditability(tableName);
+        const definition = editability.definition;
+        const hiddenIdentity = definition?.kind === 'rowid';
+        const identitySelection = hiddenIdentity
+            ? `${this.quoteIdentifier(definition.columns[0])} AS ${this.quoteIdentifier('__intelliview_row_identity__')}, `
+            : '';
+        const query = `SELECT ${identitySelection}* FROM ${this.quoteIdentifier(tableName)} LIMIT ? OFFSET ?`;
+        const stmt = this.db.prepare(query);
+        stmt.bind([safeLimit, safeOffset]);
+
+        let columns = stmt.getColumnNames();
+        const rawRows: any[][] = [];
+        while (stmt.step()) {
+            rawRows.push(stmt.get());
+        }
+        stmt.free();
+
+        if (hiddenIdentity) {
+            columns = columns.slice(1);
+        }
+
+        const values = hiddenIdentity ? rawRows.map(row => row.slice(1)) : rawRows;
+        const rowIdentities: Array<RowIdentity | null> = rawRows.map(row => {
+            if (!definition) {
+                return null;
+            }
+            if (definition.kind === 'rowid') {
+                return {
+                    kind: 'rowid',
+                    parts: [{ column: definition.columns[0], value: row[0] }]
+                };
+            }
+
+            return {
+                kind: 'primaryKey',
+                parts: definition.columns.map(column => {
+                    const columnIndex = columns.indexOf(column);
+                    if (columnIndex < 0) {
+                        throw new Error(`Primary-key column ${column} is missing from the table result.`);
+                    }
+                    return { column, value: row[columnIndex] };
+                })
+            };
         });
 
-        // Sanitize inputs
-        const sanitizedTableName = tableName.replace(/"/g, '""');
-        const sanitizedColumnName = columnName.replace(/"/g, '""');
-        
-        // Build the UPDATE query
-        const updateQuery = `UPDATE "${sanitizedTableName}" SET "${sanitizedColumnName}" = ? WHERE rowid = ?`;
-        
-        try {
-            const stmt = this.db.prepare(updateQuery);
-            
-            // Convert the new value to the appropriate type
-            let processedValue = newValue;
-            if (newValue === '' || newValue === null) {
-                processedValue = null;
-            } else if (typeof newValue === 'string') {
-                // Try to parse as number if it looks like a number
-                const numValue = parseFloat(newValue);
-                if (!isNaN(numValue) && isFinite(numValue) && newValue.trim() === numValue.toString()) {
-                    processedValue = numValue;
-                }
+        return {
+            columns,
+            values,
+            rowIdentities,
+            editable: definition !== null,
+            editError: editability.reason
+        };
+    }
+
+    private processEditedValue(newValue: any): any {
+        if (newValue === '' || newValue === null) {
+            return null;
+        }
+        if (typeof newValue === 'string') {
+            const numValue = Number(newValue);
+            if (Number.isFinite(numValue) && newValue.trim() !== '' && newValue.trim() === String(numValue)) {
+                return numValue;
             }
-            
-            this.debugLog('CellUpdate', 'Executing query:', updateQuery);
-            this.debugLog('CellUpdate', 'Parameters:', [processedValue, rowId]);
-            
-            stmt.run([processedValue, rowId]);
+        }
+        return newValue;
+    }
+
+    async updateCellData(tableName: string, identity: RowIdentity, columnName: string, newValue: any): Promise<CellUpdateResult> {
+        if (!this.db) {
+            throw new Error('Database not opened');
+        }
+
+        const editability = await this.getTableEditability(tableName);
+        const definition = editability.definition;
+        if (!definition) {
+            throw new Error(editability.reason || 'This row cannot be identified safely and uniquely.');
+        }
+
+        const tableInfo = await this.getTableInfo(tableName);
+        if (!tableInfo.some(column => column.name === columnName)) {
+            throw new Error(`Column ${columnName} does not exist in table ${tableName}.`);
+        }
+        if (!identity || identity.kind !== definition.kind || !Array.isArray(identity.parts)) {
+            throw new Error('The selected row identity is missing or no longer matches the table schema. Refresh the table and try again.');
+        }
+        const suppliedColumns = identity.parts.map(part => part?.column);
+        if (
+            suppliedColumns.length !== definition.columns.length ||
+            suppliedColumns.some((column, index) => column !== definition.columns[index]) ||
+            identity.parts.some(part => !part || part.value === undefined)
+        ) {
+            throw new Error('The selected row identity is incomplete or no longer matches the table schema. Refresh the table and try again.');
+        }
+
+        const processedValue = this.processEditedValue(newValue);
+        const whereClause = definition.columns
+            .map(column => `${this.quoteIdentifier(column)} IS ?`)
+            .join(' AND ');
+        const updateQuery = `UPDATE ${this.quoteIdentifier(tableName)} SET ${this.quoteIdentifier(columnName)} = ? WHERE ${whereClause}`;
+        const parameters = [processedValue, ...identity.parts.map(part => part.value)];
+        let stmt: any = null;
+        let transactionOpen = false;
+
+        try {
+            this.db.run('BEGIN IMMEDIATE TRANSACTION');
+            transactionOpen = true;
+            stmt = this.db.prepare(updateQuery);
+            stmt.run(parameters);
             stmt.free();
-            
-            this.debugLog('CellUpdate', `Successfully updated ${tableName}.${columnName} = ${processedValue} where rowid = ${rowId}`);
-            
-            // CRITICAL: Save changes back to the database file
+            stmt = null;
+
+            const changes = Number(this.db.getRowsModified());
+            if (changes === 0) {
+                throw new Error('No row was updated. The record may have changed or been deleted; refresh the table and try again.');
+            }
+            if (changes !== 1) {
+                throw new Error(`Critical update failure: expected one changed row but SQLite reported ${changes}. The update was rolled back.`);
+            }
+
+            this.db.run('COMMIT');
+            transactionOpen = false;
+
+            const nextIdentity: RowIdentity = {
+                kind: identity.kind,
+                parts: identity.parts.map(part => ({
+                    column: part.column,
+                    value: part.column === columnName ? processedValue : part.value
+                }))
+            };
+
             await this.saveChangesToFile();
-            // Mark as internal update so watcher ignores this event
             if (this.currentDatabasePath) {
                 markInternalUpdate(this.currentDatabasePath);
             }
-            
-            this.debugLog('CellUpdate', 'Cell update completed successfully');
-            
+
+            return {
+                changes,
+                identity: nextIdentity,
+                value: processedValue
+            };
         } catch (error) {
-            this.debugError('CellUpdate', 'Failed to update cell:', error);
+            if (stmt) {
+                stmt.free();
+            }
+            if (transactionOpen) {
+                try {
+                    this.db.run('ROLLBACK');
+                } catch {
+                    // Preserve the original update failure.
+                }
+            }
             throw new Error(`Failed to update cell: ${error}`);
         }
     }
@@ -717,27 +925,6 @@ export class DatabaseService {
         } catch (error) {
             this.debugError('ReEncrypt', 'Re-encryption error:', error);
             throw new Error(`Failed to re-encrypt database: ${error}`);
-        }
-    }
-
-    async getCellRowId(tableName: string, rowIndex: number): Promise<any> {
-        if (!this.db) {
-            throw new Error('Database not opened');
-        }
-
-        const sanitizedTableName = tableName.replace(/"/g, '""');
-        const query = `SELECT rowid FROM "${sanitizedTableName}" LIMIT 1 OFFSET ${rowIndex}`;
-        
-        try {
-            const result = await this.executeQuery(query);
-            
-            if (result.values.length > 0) {
-                const rowId = result.values[0][0];
-                return rowId;
-            }
-            throw new Error('Row not found');
-        } catch (error) {
-            throw new Error(`Failed to get row ID: ${error}`);
         }
     }
 

--- a/src/databaseService.ts
+++ b/src/databaseService.ts
@@ -533,7 +533,7 @@ export class DatabaseService {
 
     public async getTableDataPaginated(tableName: string, page: number = 1, pageSize: number = 100): Promise<EditableTableData> {
         const safePage = Number.isInteger(page) && page > 0 ? page : 1;
-        const safePageSize = Number.isInteger(pageSize) && pageSize > 0 ? pageSize : 100;
+        const safePageSize = Number.isInteger(pageSize) && pageSize > 0 ? Math.min(pageSize, 100000) : 100;
         const offset = (safePage - 1) * safePageSize;
         return this.getTableDataWithIdentities(tableName, safePageSize, offset);
     }

--- a/src/databaseService.ts
+++ b/src/databaseService.ts
@@ -627,7 +627,10 @@ export class DatabaseService {
         const identitySelection = hiddenIdentity
             ? `${this.quoteIdentifier(definition.columns[0])} AS ${this.quoteIdentifier('__intelliview_row_identity__')}, `
             : '';
-        const query = `SELECT ${identitySelection}* FROM ${this.quoteIdentifier(tableName)} LIMIT ? OFFSET ?`;
+        const identityOrder = definition
+            ? ` ORDER BY ${definition.columns.map(column => this.quoteIdentifier(column)).join(', ')}`
+            : '';
+        const query = `SELECT ${identitySelection}* FROM ${this.quoteIdentifier(tableName)}${identityOrder} LIMIT ? OFFSET ?`;
         const stmt = this.db.prepare(query);
         stmt.bind([safeLimit, safeOffset]);
 
@@ -635,8 +638,9 @@ export class DatabaseService {
         const rawRows: any[][] = [];
         const identityRows: Array<Array<SQLiteValue | bigint>> = [];
         while (stmt.step()) {
-            rawRows.push(stmt.get());
-            identityRows.push(stmt.get(null, { useBigInt: true }));
+            const identityRow = stmt.get(null, { useBigInt: true }) as Array<SQLiteValue | bigint>;
+            identityRows.push(identityRow);
+            rawRows.push(identityRow.map(value => typeof value === 'bigint' ? Number(value) : value));
         }
         stmt.free();
 
@@ -740,6 +744,7 @@ export class DatabaseService {
         let stmt: any = null;
         let transactionOpen = false;
         let committed = false;
+        let persistenceComplete = false;
         let databaseStateBeforeUpdate: Uint8Array | undefined;
         let fileStateBeforeUpdate: Buffer | undefined;
 
@@ -776,6 +781,7 @@ export class DatabaseService {
             };
 
             await this.saveChangesToFile();
+            persistenceComplete = true;
             if (this.currentDatabasePath) {
                 markInternalUpdate(this.currentDatabasePath);
             }
@@ -789,7 +795,7 @@ export class DatabaseService {
             if (stmt) {
                 stmt.free();
             }
-            let restoreSnapshot = committed;
+            let restoreSnapshot = committed && !persistenceComplete;
             if (transactionOpen) {
                 try {
                     this.db.run('ROLLBACK');
@@ -824,6 +830,10 @@ export class DatabaseService {
     }
 
     async deleteRow(tableName: string, rowIdentifier: any): Promise<void> {
+        return this.enqueueEdit(() => this.deleteRowSerialized(tableName, rowIdentifier));
+    }
+
+    private async deleteRowSerialized(tableName: string, rowIdentifier: any): Promise<void> {
         if (!this.db) {
             throw new Error('Database not opened');
         }
@@ -986,8 +996,12 @@ export class DatabaseService {
             // Replace the original file with the new encrypted version
             fs.copyFileSync(tempEncryptedFile, originalPath);
             
-            // Clean up temporary encrypted file
-            fs.unlinkSync(tempEncryptedFile);
+            // Cleanup failure does not invalidate the successfully replaced database.
+            try {
+                fs.unlinkSync(tempEncryptedFile);
+            } catch (error) {
+                this.debugWarn('ReEncrypt', `Failed to remove temporary encrypted file ${tempEncryptedFile}:`, error);
+            }
             
             this.debugLog('ReEncrypt', 'Database re-encrypted successfully');
             

--- a/src/databaseService.ts
+++ b/src/databaseService.ts
@@ -566,31 +566,43 @@ export class DatabaseService {
         }
 
         const infoStmt = this.db.prepare(`PRAGMA table_info(${this.quoteIdentifier(tableName)})`);
-        const columns: Array<{ name: string; pkOrder: number }> = [];
+        const columns: Array<{ name: string; notNull: boolean; pkOrder: number }> = [];
         while (infoStmt.step()) {
             const row = infoStmt.getAsObject();
             columns.push({
                 name: row.name as string,
+                notNull: Boolean(row.notnull),
                 pkOrder: Number(row.pk) || 0
             });
         }
         infoStmt.free();
 
+        const createSql = typeof table.sql === 'string' ? table.sql : '';
+        const withoutRowid = /\bWITHOUT\s+ROWID\b/i.test(createSql);
         const primaryKeyColumns = columns
             .filter(column => column.pkOrder > 0)
-            .sort((a, b) => a.pkOrder - b.pkOrder)
-            .map(column => column.name);
-        if (primaryKeyColumns.length > 0) {
+            .sort((a, b) => a.pkOrder - b.pkOrder);
+        const indexStmt = this.db.prepare(`PRAGMA index_list(${this.quoteIdentifier(tableName)})`);
+        let hasPrimaryKeyIndex = false;
+        while (indexStmt.step()) {
+            if (indexStmt.getAsObject().origin === 'pk') {
+                hasPrimaryKeyIndex = true;
+                break;
+            }
+        }
+        indexStmt.free();
+        const primaryKeyIsRowidAlias = primaryKeyColumns.length === 1 && !hasPrimaryKeyIndex;
+        const primaryKeyIsNonNull = withoutRowid || primaryKeyIsRowidAlias || primaryKeyColumns.every(column => column.notNull);
+        if (primaryKeyColumns.length > 0 && primaryKeyIsNonNull) {
             return {
                 definition: {
                     kind: 'primaryKey',
-                    columns: primaryKeyColumns
+                    columns: primaryKeyColumns.map(column => column.name)
                 }
             };
         }
 
-        const createSql = typeof table.sql === 'string' ? table.sql : '';
-        if (/\bWITHOUT\s+ROWID\b/i.test(createSql)) {
+        if (withoutRowid) {
             return {
                 definition: null,
                 reason: 'This WITHOUT ROWID table has no declared primary key and cannot be edited safely.'
@@ -640,7 +652,13 @@ export class DatabaseService {
         while (stmt.step()) {
             const identityRow = stmt.get(null, { useBigInt: true }) as Array<SQLiteValue | bigint>;
             identityRows.push(identityRow);
-            rawRows.push(identityRow.map(value => typeof value === 'bigint' ? Number(value) : value));
+            rawRows.push(identityRow.map(value => {
+                if (typeof value !== 'bigint') {
+                    return value;
+                }
+                const numericValue = Number(value);
+                return Number.isSafeInteger(numericValue) ? numericValue : value.toString();
+            }));
         }
         stmt.free();
 
@@ -682,7 +700,7 @@ export class DatabaseService {
     }
 
     private processEditedValue(newValue: unknown): SQLiteValue {
-        if (newValue === '' || newValue === null) {
+        if (newValue === null) {
             return null;
         }
         if (typeof newValue === 'string') {

--- a/src/databaseService.ts
+++ b/src/databaseService.ts
@@ -768,6 +768,7 @@ export class DatabaseService {
         let fileStateBeforeUpdate: Buffer | undefined;
 
         try {
+            databaseStateBeforeUpdate = this.db.export();
             this.db.run('BEGIN IMMEDIATE TRANSACTION');
             transactionOpen = true;
             stmt = this.db.prepare(updateQuery);
@@ -783,7 +784,7 @@ export class DatabaseService {
                 throw new Error(`Critical update failure: expected one changed row but SQLite reported ${changes}. The update was rolled back.`);
             }
 
-            ({ databaseState: databaseStateBeforeUpdate, fileState: fileStateBeforeUpdate } = this.capturePersistenceSnapshot());
+            fileStateBeforeUpdate = this.captureFileState();
             this.db.run('COMMIT');
             transactionOpen = false;
             committed = true;
@@ -822,9 +823,6 @@ export class DatabaseService {
                     transactionOpen = false;
                 }
             }
-            if (restoreSnapshot && !databaseStateBeforeUpdate) {
-                ({ databaseState: databaseStateBeforeUpdate, fileState: fileStateBeforeUpdate } = this.capturePersistenceSnapshot());
-            }
             if (restoreSnapshot && databaseStateBeforeUpdate) {
                 try {
                     this.restoreDatabaseState(databaseStateBeforeUpdate, fileStateBeforeUpdate);
@@ -836,16 +834,12 @@ export class DatabaseService {
         }
     }
 
-    private capturePersistenceSnapshot(): { databaseState: Uint8Array; fileState: Buffer } {
+    private captureFileState(): Buffer {
         if (!this.currentDatabasePath) {
             throw new Error('No database path available for saving');
         }
 
-        const fileState = fs.readFileSync(this.currentDatabasePath);
-        const databaseState = this.tempDecryptedPath
-            ? fs.readFileSync(this.tempDecryptedPath)
-            : fileState;
-        return { databaseState, fileState };
+        return fs.readFileSync(this.currentDatabasePath);
     }
 
     private restoreDatabaseState(databaseState: Uint8Array, fileState?: Buffer): void {
@@ -924,6 +918,7 @@ export class DatabaseService {
             this.debugLog('DeleteRow', 'Executing query:', deleteQuery);
             this.debugLog('DeleteRow', 'Parameters:', parameters);
 
+            databaseStateBeforeDelete = this.db.export();
             this.db.run('BEGIN IMMEDIATE TRANSACTION');
             transactionOpen = true;
             stmt = this.db.prepare(deleteQuery);
@@ -943,7 +938,7 @@ export class DatabaseService {
             
             this.debugLog('DeleteRow', `Rows remaining in table: ${rowCount}`);
             
-            ({ databaseState: databaseStateBeforeDelete, fileState: fileStateBeforeDelete } = this.capturePersistenceSnapshot());
+            fileStateBeforeDelete = this.captureFileState();
             this.db.run('COMMIT');
             transactionOpen = false;
             committed = true;
@@ -970,9 +965,6 @@ export class DatabaseService {
                 } finally {
                     transactionOpen = false;
                 }
-            }
-            if (restoreSnapshot && !databaseStateBeforeDelete) {
-                ({ databaseState: databaseStateBeforeDelete, fileState: fileStateBeforeDelete } = this.capturePersistenceSnapshot());
             }
             if (restoreSnapshot && databaseStateBeforeDelete) {
                 try {

--- a/src/databaseService.ts
+++ b/src/databaseService.ts
@@ -925,6 +925,14 @@ export class DatabaseService {
             stmt.run(parameters);
             stmt.free();
             stmt = null;
+
+            const changes = Number(this.db.getRowsModified());
+            if (changes === 0) {
+                throw new Error('No row was deleted. The record may have changed or already been deleted; refresh the table and try again.');
+            }
+            if (changes !== 1) {
+                throw new Error(`Critical delete failure: expected one changed row but SQLite reported ${changes}. The deletion was rolled back.`);
+            }
             
             this.debugLog('DeleteRow', 'Delete query executed successfully');
             

--- a/src/databaseService.ts
+++ b/src/databaseService.ts
@@ -631,7 +631,7 @@ export class DatabaseService {
             throw new Error('Database not opened');
         }
 
-        const safeLimit = Number.isInteger(limit) && limit > 0 ? limit : 1000;
+        const safeLimit = Number.isSafeInteger(limit) && limit > 0 ? Math.min(limit, 100000) : 1000;
         const safeOffset = Number.isInteger(offset) && offset >= 0 ? offset : 0;
         const editability = await this.getTableEditability(tableName);
         const definition = editability.definition;

--- a/src/databaseService.ts
+++ b/src/databaseService.ts
@@ -767,10 +767,6 @@ export class DatabaseService {
         let fileStateBeforeUpdate: Buffer | undefined;
 
         try {
-            databaseStateBeforeUpdate = this.db.export();
-            if (this.currentDatabasePath) {
-                fileStateBeforeUpdate = fs.readFileSync(this.currentDatabasePath);
-            }
             this.db.run('BEGIN IMMEDIATE TRANSACTION');
             transactionOpen = true;
             stmt = this.db.prepare(updateQuery);
@@ -786,6 +782,7 @@ export class DatabaseService {
                 throw new Error(`Critical update failure: expected one changed row but SQLite reported ${changes}. The update was rolled back.`);
             }
 
+            ({ databaseState: databaseStateBeforeUpdate, fileState: fileStateBeforeUpdate } = this.capturePersistenceSnapshot());
             this.db.run('COMMIT');
             transactionOpen = false;
             committed = true;
@@ -798,7 +795,8 @@ export class DatabaseService {
                 }))
             };
 
-            await this.saveChangesToFile();
+            const databaseStateAfterUpdate = this.db.export();
+            await this.saveChangesToFile(databaseStateAfterUpdate);
             persistenceComplete = true;
             if (this.currentDatabasePath) {
                 markInternalUpdate(this.currentDatabasePath);
@@ -823,6 +821,9 @@ export class DatabaseService {
                     transactionOpen = false;
                 }
             }
+            if (restoreSnapshot && !databaseStateBeforeUpdate) {
+                ({ databaseState: databaseStateBeforeUpdate, fileState: fileStateBeforeUpdate } = this.capturePersistenceSnapshot());
+            }
             if (restoreSnapshot && databaseStateBeforeUpdate) {
                 try {
                     this.restoreDatabaseState(databaseStateBeforeUpdate, fileStateBeforeUpdate);
@@ -832,6 +833,18 @@ export class DatabaseService {
             }
             throw new Error(`Failed to update cell: ${error}`);
         }
+    }
+
+    private capturePersistenceSnapshot(): { databaseState: Uint8Array; fileState: Buffer } {
+        if (!this.currentDatabasePath) {
+            throw new Error('No database path available for saving');
+        }
+
+        const fileState = fs.readFileSync(this.currentDatabasePath);
+        const databaseState = this.tempDecryptedPath
+            ? fs.readFileSync(this.tempDecryptedPath)
+            : fileState;
+        return { databaseState, fileState };
     }
 
     private restoreDatabaseState(databaseState: Uint8Array, fileState?: Buffer): void {
@@ -863,6 +876,13 @@ export class DatabaseService {
 
         // Sanitize table name
         const sanitizedTableName = tableName.replace(/"/g, '""');
+        let stmt: any = null;
+        let countStmt: any = null;
+        let transactionOpen = false;
+        let committed = false;
+        let persistenceComplete = false;
+        let databaseStateBeforeDelete: Uint8Array | undefined;
+        let fileStateBeforeDelete: Buffer | undefined;
         
         try {
             let deleteQuery: string;
@@ -902,24 +922,34 @@ export class DatabaseService {
             
             this.debugLog('DeleteRow', 'Executing query:', deleteQuery);
             this.debugLog('DeleteRow', 'Parameters:', parameters);
-            
-            const stmt = this.db.prepare(deleteQuery);
+
+            this.db.run('BEGIN IMMEDIATE TRANSACTION');
+            transactionOpen = true;
+            stmt = this.db.prepare(deleteQuery);
             stmt.run(parameters);
             stmt.free();
+            stmt = null;
             
             this.debugLog('DeleteRow', 'Delete query executed successfully');
             
             // Verify the deletion by checking row count
             const countQuery = `SELECT COUNT(*) as count FROM "${sanitizedTableName}"`;
-            const countStmt = this.db.prepare(countQuery);
+            countStmt = this.db.prepare(countQuery);
             const countResult = countStmt.step();
             const rowCount = countResult ? countStmt.get()[0] : 0;
             countStmt.free();
+            countStmt = null;
             
             this.debugLog('DeleteRow', `Rows remaining in table: ${rowCount}`);
             
-            // CRITICAL: Save changes back to the database file
-            await this.saveChangesToFile();
+            ({ databaseState: databaseStateBeforeDelete, fileState: fileStateBeforeDelete } = this.capturePersistenceSnapshot());
+            this.db.run('COMMIT');
+            transactionOpen = false;
+            committed = true;
+
+            const databaseStateAfterDelete = this.db.export();
+            await this.saveChangesToFile(databaseStateAfterDelete);
+            persistenceComplete = true;
             // Mark as internal update so watcher ignores this event
             if (this.currentDatabasePath) {
                 markInternalUpdate(this.currentDatabasePath);
@@ -928,6 +958,28 @@ export class DatabaseService {
             this.debugLog('DeleteRow', 'Row deletion completed successfully');
             
         } catch (error) {
+            stmt?.free();
+            countStmt?.free();
+            let restoreSnapshot = committed && !persistenceComplete;
+            if (transactionOpen) {
+                try {
+                    this.db.run('ROLLBACK');
+                } catch {
+                    restoreSnapshot = true;
+                } finally {
+                    transactionOpen = false;
+                }
+            }
+            if (restoreSnapshot && !databaseStateBeforeDelete) {
+                ({ databaseState: databaseStateBeforeDelete, fileState: fileStateBeforeDelete } = this.capturePersistenceSnapshot());
+            }
+            if (restoreSnapshot && databaseStateBeforeDelete) {
+                try {
+                    this.restoreDatabaseState(databaseStateBeforeDelete, fileStateBeforeDelete);
+                } catch (restoreError) {
+                    throw new Error(`Failed to delete row: ${error}. Failed to restore the previous database state: ${restoreError}`);
+                }
+            }
             this.debugError('DeleteRow', 'Failed to delete row:', error);
             throw new Error(`Failed to delete row: ${error}`);
         }
@@ -936,7 +988,7 @@ export class DatabaseService {
     /**
      * Save changes from the in-memory database back to the file
      */
-    private async saveChangesToFile(): Promise<void> {
+    private async saveChangesToFile(databaseState?: Uint8Array): Promise<void> {
         if (!this.db) {
             throw new Error('Database not opened');
         }
@@ -946,8 +998,8 @@ export class DatabaseService {
         this.debugLog('SaveFile', `Temp decrypted path: ${this.tempDecryptedPath}`);
 
         try {
-            // Export the current database state
-            const data = this.db.export();
+            // Reuse the caller's committed export when available.
+            const data = databaseState ?? this.db.export();
             const buffer = Buffer.from(data);
             
             this.debugLog('SaveFile', `Exported ${buffer.length} bytes`);

--- a/src/databaseService.ts
+++ b/src/databaseService.ts
@@ -121,7 +121,8 @@ export class DatabaseService {
 
     private serializeIdentityValue(value: unknown): SQLiteValue {
         if (typeof value === 'bigint') {
-            return value.toString();
+            const numericValue = Number(value);
+            return Number.isSafeInteger(numericValue) ? numericValue : value.toString();
         }
         if (value === null || typeof value === 'string' || value instanceof Uint8Array) {
             return value;

--- a/src/databaseService.ts
+++ b/src/databaseService.ts
@@ -43,9 +43,11 @@ export interface QueryResult {
     values: any[][];
 }
 
+export type SQLiteValue = number | string | Uint8Array | null;
+
 export interface RowIdentityPart {
     column: string;
-    value: any;
+    value: SQLiteValue;
 }
 
 export interface RowIdentity {
@@ -62,7 +64,7 @@ export interface EditableTableData extends QueryResult {
 export interface CellUpdateResult {
     changes: number;
     identity: RowIdentity;
-    value: any;
+    value: SQLiteValue;
 }
 
 interface TableIdentityDefinition {
@@ -92,6 +94,7 @@ export class DatabaseService {
     private tempDecryptedPath: string | null = null;
     private currentDatabasePath: string | null = null;
     private currentEncryptionKey: string | null = null;
+    private editQueue: Promise<void> = Promise.resolve();
     private isDevelopment = process.env.NODE_ENV === 'development' || (typeof process !== 'undefined' && process.env.VSCODE_PID !== undefined);
 
     private debugLog(component: string, message: string, ...args: any[]): void {
@@ -114,6 +117,25 @@ export class DatabaseService {
 
     private quoteIdentifier(identifier: string): string {
         return `"${identifier.replace(/"/g, '""')}"`;
+    }
+
+    private serializeIdentityValue(value: unknown): SQLiteValue {
+        if (typeof value === 'bigint') {
+            return value.toString();
+        }
+        if (value === null || typeof value === 'string' || value instanceof Uint8Array) {
+            return value;
+        }
+        if (typeof value === 'number' && Number.isFinite(value)) {
+            return value;
+        }
+        throw new Error('Row identity contains an unsupported SQLite value.');
+    }
+
+    private enqueueEdit<T>(operation: () => Promise<T>): Promise<T> {
+        const queued = this.editQueue.then(operation, operation);
+        this.editQueue = queued.then(() => undefined, () => undefined);
+        return queued;
     }
 
     private getSettings() {
@@ -611,8 +633,10 @@ export class DatabaseService {
 
         let columns = stmt.getColumnNames();
         const rawRows: any[][] = [];
+        const identityRows: Array<Array<SQLiteValue | bigint>> = [];
         while (stmt.step()) {
             rawRows.push(stmt.get());
+            identityRows.push(stmt.get(null, { useBigInt: true }));
         }
         stmt.free();
 
@@ -621,14 +645,14 @@ export class DatabaseService {
         }
 
         const values = hiddenIdentity ? rawRows.map(row => row.slice(1)) : rawRows;
-        const rowIdentities: Array<RowIdentity | null> = rawRows.map(row => {
+        const rowIdentities: Array<RowIdentity | null> = identityRows.map(row => {
             if (!definition) {
                 return null;
             }
             if (definition.kind === 'rowid') {
                 return {
                     kind: 'rowid',
-                    parts: [{ column: definition.columns[0], value: row[0] }]
+                    parts: [{ column: definition.columns[0], value: this.serializeIdentityValue(row[0]) }]
                 };
             }
 
@@ -639,7 +663,7 @@ export class DatabaseService {
                     if (columnIndex < 0) {
                         throw new Error(`Primary-key column ${column} is missing from the table result.`);
                     }
-                    return { column, value: row[columnIndex] };
+                    return { column, value: this.serializeIdentityValue(row[columnIndex]) };
                 })
             };
         });
@@ -653,20 +677,34 @@ export class DatabaseService {
         };
     }
 
-    private processEditedValue(newValue: any): any {
+    private processEditedValue(newValue: unknown): SQLiteValue {
         if (newValue === '' || newValue === null) {
             return null;
         }
         if (typeof newValue === 'string') {
             const numValue = Number(newValue);
             if (Number.isFinite(numValue) && newValue.trim() !== '' && newValue.trim() === String(numValue)) {
+                if (Number.isInteger(numValue) && !Number.isSafeInteger(numValue)) {
+                    return newValue;
+                }
                 return numValue;
             }
+            return newValue;
         }
-        return newValue;
+        if (typeof newValue === 'number' && Number.isFinite(newValue)) {
+            return newValue;
+        }
+        if (newValue instanceof Uint8Array) {
+            return newValue;
+        }
+        throw new Error('The edited value is not a supported SQLite value.');
     }
 
-    async updateCellData(tableName: string, identity: RowIdentity, columnName: string, newValue: any): Promise<CellUpdateResult> {
+    async updateCellData(tableName: string, identity: RowIdentity, columnName: string, newValue: unknown): Promise<CellUpdateResult> {
+        return this.enqueueEdit(() => this.updateCellDataSerialized(tableName, identity, columnName, newValue));
+    }
+
+    private async updateCellDataSerialized(tableName: string, identity: RowIdentity, columnName: string, newValue: unknown): Promise<CellUpdateResult> {
         if (!this.db) {
             throw new Error('Database not opened');
         }
@@ -701,8 +739,15 @@ export class DatabaseService {
         const parameters = [processedValue, ...identity.parts.map(part => part.value)];
         let stmt: any = null;
         let transactionOpen = false;
+        let committed = false;
+        let databaseStateBeforeUpdate: Uint8Array | undefined;
+        let fileStateBeforeUpdate: Buffer | undefined;
 
         try {
+            databaseStateBeforeUpdate = this.db.export();
+            if (this.currentDatabasePath) {
+                fileStateBeforeUpdate = fs.readFileSync(this.currentDatabasePath);
+            }
             this.db.run('BEGIN IMMEDIATE TRANSACTION');
             transactionOpen = true;
             stmt = this.db.prepare(updateQuery);
@@ -720,6 +765,7 @@ export class DatabaseService {
 
             this.db.run('COMMIT');
             transactionOpen = false;
+            committed = true;
 
             const nextIdentity: RowIdentity = {
                 kind: identity.kind,
@@ -743,14 +789,37 @@ export class DatabaseService {
             if (stmt) {
                 stmt.free();
             }
+            let restoreSnapshot = committed;
             if (transactionOpen) {
                 try {
                     this.db.run('ROLLBACK');
                 } catch {
-                    // Preserve the original update failure.
+                    restoreSnapshot = true;
+                } finally {
+                    transactionOpen = false;
+                }
+            }
+            if (restoreSnapshot && databaseStateBeforeUpdate) {
+                try {
+                    this.restoreDatabaseState(databaseStateBeforeUpdate, fileStateBeforeUpdate);
+                } catch (restoreError) {
+                    throw new Error(`Failed to update cell: ${error}. Failed to restore the previous database state: ${restoreError}`);
                 }
             }
             throw new Error(`Failed to update cell: ${error}`);
+        }
+    }
+
+    private restoreDatabaseState(databaseState: Uint8Array, fileState?: Buffer): void {
+        const modifiedDatabase = this.db;
+        this.db = new this.SQL.Database(databaseState);
+        modifiedDatabase?.close();
+
+        if (this.currentDatabasePath && fileState) {
+            fs.writeFileSync(this.currentDatabasePath, fileState);
+        }
+        if (this.tempDecryptedPath) {
+            fs.writeFileSync(this.tempDecryptedPath, Buffer.from(databaseState));
         }
     }
 

--- a/src/test/cellEditing.test.ts
+++ b/src/test/cellEditing.test.ts
@@ -372,6 +372,40 @@ suite('Stable cell editing', () => {
         assert.deepStrictEqual(readRows('SELECT id, value FROM records'), [{ id: 1, value: 'original' }]);
     });
 
+    test('preserves earlier in-memory query changes when later persistence fails', async () => {
+        createDatabase(`
+            CREATE TABLE records (id INTEGER PRIMARY KEY, value TEXT);
+            INSERT INTO records VALUES (1, 'disk-one'), (2, 'disk-two'), (3, 'disk-three');
+        `);
+        await service.openDatabase(databasePath);
+        await service.executeQuery("UPDATE records SET value = 'query-change' WHERE id = 1");
+        const data = await service.getTableData('records');
+        (service as any).saveChangesToFile = async () => {
+            throw new Error('forced persistence failure');
+        };
+
+        await assert.rejects(
+            service.updateCellData('records', identityFor(data, 'id', 2), 'value', 'must-not-stick'),
+            /forced persistence failure/
+        );
+        await assert.rejects(
+            service.deleteRow('records', { column: 'id', value: 3 }),
+            /forced persistence failure/
+        );
+
+        const afterFailures = await service.getTableData('records');
+        assert.deepStrictEqual(afterFailures.values, [
+            [1, 'query-change'],
+            [2, 'disk-two'],
+            [3, 'disk-three']
+        ]);
+        assert.deepStrictEqual(readRows('SELECT id, value FROM records ORDER BY id'), [
+            { id: 1, value: 'disk-one' },
+            { id: 2, value: 'disk-two' },
+            { id: 3, value: 'disk-three' }
+        ]);
+    });
+
     test('serializes persistence for concurrent updates and deletes', async () => {
         createDatabase(`
             CREATE TABLE records (id INTEGER PRIMARY KEY, value TEXT);

--- a/src/test/cellEditing.test.ts
+++ b/src/test/cellEditing.test.ts
@@ -4,6 +4,7 @@ import * as os from 'os';
 import * as path from 'path';
 import initSqlJs = require('sql.js');
 import { DatabaseService, EditableTableData, RowIdentity } from '../databaseService';
+import { isWebviewToExtensionMessage } from '../webviewMessages';
 
 suite('Stable cell editing', () => {
     let tempDir: string;
@@ -326,6 +327,43 @@ suite('Stable cell editing', () => {
             readRows('SELECT CAST(rowid AS TEXT) AS rowid, value FROM rowid_keys'),
             [{ rowid: '9223372036854775805', value: 'updated-rowid-key' }]
         );
+    });
+
+    test('round-trips BLOB primary-key identities through webview messages', async () => {
+        createDatabase(`
+            CREATE TABLE blob_keys (id BLOB PRIMARY KEY NOT NULL, value TEXT);
+            INSERT INTO blob_keys VALUES (X'0001FF', 'first'), (X'0002FF', 'second');
+        `);
+        await service.openDatabase(databasePath);
+        const data = await service.getTableData('blob_keys');
+        const message = JSON.parse(JSON.stringify({
+            type: 'updateCellData',
+            tableName: 'blob_keys',
+            requestId: 'blob-update',
+            rowIdentity: data.rowIdentities[0],
+            columnName: 'value',
+            newValue: 'updated-first'
+        }));
+
+        assert.deepStrictEqual(message.rowIdentity.parts[0].value, { type: 'blob', base64: 'AAH/' });
+        assert.ok(isWebviewToExtensionMessage(message));
+        assert.strictEqual(message.type, 'updateCellData');
+        await service.updateCellData(message.tableName, message.rowIdentity, message.columnName, message.newValue);
+
+        const invalidMessage = {
+            ...message,
+            rowIdentity: {
+                ...message.rowIdentity,
+                parts: [{ column: 'id', value: { type: 'blob', base64: 'not-base64' } }]
+            }
+        };
+        assert.strictEqual(isWebviewToExtensionMessage(invalidMessage), false);
+
+        service.closeDatabase();
+        assert.deepStrictEqual(readRows('SELECT hex(id) AS id, value FROM blob_keys ORDER BY id'), [
+            { id: '0001FF', value: 'updated-first' },
+            { id: '0002FF', value: 'second' }
+        ]);
     });
 
     test('restores committed in-memory state when persistence fails', async () => {

--- a/src/test/cellEditing.test.ts
+++ b/src/test/cellEditing.test.ts
@@ -157,6 +157,7 @@ suite('Stable cell editing', () => {
         const secondPage = await service.getTableDataPaginated('notes', 2, 2);
 
         assert.strictEqual(secondPage.rowIdentities[0]?.kind, 'rowid');
+        assert.strictEqual(secondPage.rowIdentities[0]?.parts[0].value, 3);
         assert.deepStrictEqual(secondPage.values.map(row => row[0]), ['three', 'four']);
         await service.updateCellData('notes', secondPage.rowIdentities[0]!, 'value', 'page-two-first');
 

--- a/src/test/cellEditing.test.ts
+++ b/src/test/cellEditing.test.ts
@@ -346,6 +346,29 @@ suite('Stable cell editing', () => {
         assert.deepStrictEqual(readRows('SELECT id, value FROM records'), [{ id: 1, value: 'original' }]);
     });
 
+    test('restores deleted rows in memory and on disk when persistence fails', async () => {
+        createDatabase(`
+            CREATE TABLE records (id INTEGER PRIMARY KEY, value TEXT);
+            INSERT INTO records VALUES (1, 'original');
+        `);
+        await service.openDatabase(databasePath);
+        const saveChangesToFile = (service as any).saveChangesToFile.bind(service);
+        (service as any).saveChangesToFile = async (databaseState?: Uint8Array) => {
+            assert.ok(databaseState instanceof Uint8Array);
+            await saveChangesToFile(databaseState);
+            throw new Error('forced delete persistence failure');
+        };
+
+        await assert.rejects(
+            service.deleteRow('records', { column: 'id', value: 1 }),
+            /forced delete persistence failure/
+        );
+
+        const afterFailure = await service.getTableData('records');
+        assert.deepStrictEqual(afterFailure.values, [[1, 'original']]);
+        assert.deepStrictEqual(readRows('SELECT id, value FROM records'), [{ id: 1, value: 'original' }]);
+    });
+
     test('serializes persistence for concurrent updates and deletes', async () => {
         createDatabase(`
             CREATE TABLE records (id INTEGER PRIMARY KEY, value TEXT);
@@ -356,12 +379,12 @@ suite('Stable cell editing', () => {
         const saveChangesToFile = (service as any).saveChangesToFile.bind(service);
         let activeSaves = 0;
         let maxActiveSaves = 0;
-        (service as any).saveChangesToFile = async () => {
+        (service as any).saveChangesToFile = async (databaseState?: Uint8Array) => {
             activeSaves++;
             maxActiveSaves = Math.max(maxActiveSaves, activeSaves);
             await new Promise(resolve => setTimeout(resolve, 10));
             try {
-                await saveChangesToFile();
+                await saveChangesToFile(databaseState);
             } finally {
                 activeSaves--;
             }

--- a/src/test/cellEditing.test.ts
+++ b/src/test/cellEditing.test.ts
@@ -170,6 +170,24 @@ suite('Stable cell editing', () => {
         ]);
     });
 
+    test('paginates deterministically by the stable row identity', async () => {
+        createDatabase(`
+            CREATE TABLE ordered_records (code TEXT PRIMARY KEY, value TEXT);
+            INSERT INTO ordered_records VALUES ('charlie', 'C'), ('alpha', 'A'), ('bravo', 'B');
+        `);
+        await service.openDatabase(databasePath);
+
+        const firstPage = await service.getTableDataPaginated('ordered_records', 1, 2);
+        const secondPage = await service.getTableDataPaginated('ordered_records', 2, 2);
+
+        assert.deepStrictEqual(firstPage.values.map(row => row[0]), ['alpha', 'bravo']);
+        assert.deepStrictEqual(secondPage.values.map(row => row[0]), ['charlie']);
+        assert.deepStrictEqual(
+            firstPage.rowIdentities.map(identity => identity?.parts[0].value),
+            ['alpha', 'bravo']
+        );
+    });
+
     test('supports text and composite primary keys, WITHOUT ROWID, and primary-key edits', async () => {
         createDatabase(`
             CREATE TABLE text_keys (code TEXT PRIMARY KEY, value TEXT);
@@ -285,10 +303,10 @@ suite('Stable cell editing', () => {
         assert.deepStrictEqual(readRows('SELECT id, value FROM records'), [{ id: 1, value: 'original' }]);
     });
 
-    test('serializes persistence for concurrent cell edits', async () => {
+    test('serializes persistence for concurrent updates and deletes', async () => {
         createDatabase(`
             CREATE TABLE records (id INTEGER PRIMARY KEY, value TEXT);
-            INSERT INTO records VALUES (1, 'one'), (2, 'two');
+            INSERT INTO records VALUES (1, 'one'), (2, 'two'), (3, 'three');
         `);
         await service.openDatabase(databasePath);
         const data = await service.getTableData('records');
@@ -308,7 +326,8 @@ suite('Stable cell editing', () => {
 
         await Promise.all([
             service.updateCellData('records', identityFor(data, 'id', 1), 'value', 'updated-one'),
-            service.updateCellData('records', identityFor(data, 'id', 2), 'value', 'updated-two')
+            service.updateCellData('records', identityFor(data, 'id', 2), 'value', 'updated-two'),
+            service.deleteRow('records', { column: 'id', value: 3 })
         ]);
 
         assert.strictEqual(maxActiveSaves, 1);

--- a/src/test/cellEditing.test.ts
+++ b/src/test/cellEditing.test.ts
@@ -172,7 +172,7 @@ suite('Stable cell editing', () => {
 
     test('paginates deterministically by the stable row identity', async () => {
         createDatabase(`
-            CREATE TABLE ordered_records (code TEXT PRIMARY KEY, value TEXT);
+            CREATE TABLE ordered_records (code TEXT PRIMARY KEY NOT NULL, value TEXT);
             INSERT INTO ordered_records VALUES ('charlie', 'C'), ('alpha', 'A'), ('bravo', 'B');
         `);
         await service.openDatabase(databasePath);
@@ -190,7 +190,7 @@ suite('Stable cell editing', () => {
 
     test('supports text and composite primary keys, WITHOUT ROWID, and primary-key edits', async () => {
         createDatabase(`
-            CREATE TABLE text_keys (code TEXT PRIMARY KEY, value TEXT);
+            CREATE TABLE text_keys (code TEXT PRIMARY KEY NOT NULL, value TEXT);
             INSERT INTO text_keys VALUES ('alpha', 'A'), ('beta', 'B');
             CREATE TABLE memberships (
                 account TEXT,
@@ -223,10 +223,28 @@ suite('Stable cell editing', () => {
         ]);
     });
 
+    test('uses rowid when a declared primary key permits null values', async () => {
+        createDatabase(`
+            CREATE TABLE nullable_keys (code TEXT PRIMARY KEY, value TEXT);
+            INSERT INTO nullable_keys VALUES (NULL, 'first'), (NULL, 'second');
+        `);
+        await service.openDatabase(databasePath);
+
+        const data = await service.getTableData('nullable_keys');
+        assert.deepStrictEqual(data.rowIdentities.map(identity => identity?.kind), ['rowid', 'rowid']);
+        await service.updateCellData('nullable_keys', data.rowIdentities[1]!, 'value', 'updated-second');
+
+        service.closeDatabase();
+        assert.deepStrictEqual(readRows('SELECT rowid, code, value FROM nullable_keys ORDER BY rowid'), [
+            { rowid: 1, code: null, value: 'first' },
+            { rowid: 2, code: null, value: 'updated-second' }
+        ]);
+    });
+
     test('binds quotes, Unicode, and null values without changing the selected identity', async () => {
         createDatabase(`
             CREATE TABLE content (id INTEGER PRIMARY KEY, value TEXT);
-            INSERT INTO content VALUES (1, 'first'), (5, 'second'), (40, 'third');
+            INSERT INTO content VALUES (1, 'first'), (5, 'second'), (6, 'nonempty'), (40, 'third');
             CREATE TABLE "odd""table" ("key""part" TEXT PRIMARY KEY, "value""text" TEXT);
             INSERT INTO "odd""table" VALUES ('quoted-key', 'old');
         `);
@@ -235,6 +253,8 @@ suite('Stable cell editing', () => {
 
         await service.updateCellData('content', identityFor(data, 'id', 1), 'value', "O'Reilly — 雪");
         await service.updateCellData('content', identityFor(data, 'id', 5), 'value', null);
+        const emptyStringEdit = await service.updateCellData('content', identityFor(data, 'id', 6), 'value', '');
+        assert.strictEqual(emptyStringEdit.value, '');
         const quoted = await service.getTableData('odd"table');
         await service.updateCellData(
             'odd"table',
@@ -247,6 +267,7 @@ suite('Stable cell editing', () => {
         assert.deepStrictEqual(readRows('SELECT id, value FROM content ORDER BY id'), [
             { id: 1, value: "O'Reilly — 雪" },
             { id: 5, value: null },
+            { id: 6, value: '' },
             { id: 40, value: 'third' }
         ]);
         assert.deepStrictEqual(readRows('SELECT "value""text" AS value FROM "odd""table"'), [
@@ -264,10 +285,12 @@ suite('Stable cell editing', () => {
         await service.openDatabase(databasePath);
 
         const integerRows = await service.getTableData('integer_keys');
+        assert.strictEqual(integerRows.values[0][0], '9223372036854775806');
         assert.strictEqual(integerRows.rowIdentities[0]?.parts[0].value, '9223372036854775806');
         await service.updateCellData('integer_keys', integerRows.rowIdentities[0]!, 'value', 'updated-integer-key');
 
         const rowidRows = await service.getTableData('rowid_keys');
+        assert.strictEqual(rowidRows.values[0][0], 'rowid-key');
         assert.strictEqual(rowidRows.rowIdentities[0]?.parts[0].value, '9223372036854775805');
         await service.updateCellData('rowid_keys', rowidRows.rowIdentities[0]!, 'value', 'updated-rowid-key');
 
@@ -337,28 +360,22 @@ suite('Stable cell editing', () => {
         ]);
     });
 
-    test('rejects stale, ambiguous, and unavailable row identities without persisting changes', async () => {
+    test('rejects stale and unavailable row identities without persisting changes', async () => {
         createDatabase(`
-            CREATE TABLE ambiguous (a TEXT, b TEXT, value TEXT, PRIMARY KEY (a, b));
-            INSERT INTO ambiguous VALUES (NULL, 'same', 'first'), (NULL, 'same', 'second');
+            CREATE TABLE stable (a TEXT NOT NULL, b TEXT NOT NULL, value TEXT, PRIMARY KEY (a, b));
+            INSERT INTO stable VALUES ('one', 'same', 'first'), ('two', 'same', 'second');
             CREATE TABLE shadowed (rowid TEXT, _rowid_ TEXT, oid TEXT, value TEXT);
             INSERT INTO shadowed VALUES ('r', 'u', 'o', 'unchanged');
-            CREATE VIEW ambiguous_view AS SELECT * FROM ambiguous;
+            CREATE VIEW stable_view AS SELECT * FROM stable;
         `);
         await service.openDatabase(databasePath);
-
-        const ambiguous = await service.getTableData('ambiguous');
-        await assert.rejects(
-            service.updateCellData('ambiguous', ambiguous.rowIdentities[0]!, 'value', 'must-rollback'),
-            /expected one changed row but SQLite reported 2/
-        );
 
         const staleIdentity: RowIdentity = {
             kind: 'primaryKey',
             parts: [{ column: 'a', value: 'missing' }, { column: 'b', value: 'missing' }]
         };
         await assert.rejects(
-            service.updateCellData('ambiguous', staleIdentity, 'value', 'must-not-write'),
+            service.updateCellData('stable', staleIdentity, 'value', 'must-not-write'),
             /No row was updated/
         );
 
@@ -367,12 +384,12 @@ suite('Stable cell editing', () => {
         assert.ok(shadowed.rowIdentities.every(identity => identity === null));
         assert.match(shadowed.editError || '', /rowid aliases are shadowed/);
 
-        const view = await service.getTableData('ambiguous_view');
+        const view = await service.getTableData('stable_view');
         assert.strictEqual(view.editable, false);
         assert.match(view.editError || '', /Views cannot be edited safely/);
 
         service.closeDatabase();
-        assert.deepStrictEqual(readRows('SELECT value FROM ambiguous ORDER BY rowid'), [
+        assert.deepStrictEqual(readRows('SELECT value FROM stable ORDER BY rowid'), [
             { value: 'first' },
             { value: 'second' }
         ]);

--- a/src/test/cellEditing.test.ts
+++ b/src/test/cellEditing.test.ts
@@ -204,9 +204,11 @@ suite('Stable cell editing', () => {
 
         const capped = await service.getTableData('many_rows', 100001);
         const unsafe = await service.getTableData('many_rows', Number.MAX_SAFE_INTEGER + 1);
+        const secondCappedPage = await service.getTableDataPaginated('many_rows', 2, 200000);
 
         assert.strictEqual(capped.values.length, 100000);
         assert.strictEqual(unsafe.values.length, 1000);
+        assert.deepStrictEqual(secondCappedPage.values, [[100001]]);
     });
 
     test('supports text and composite primary keys, WITHOUT ROWID, and primary-key edits', async () => {

--- a/src/test/cellEditing.test.ts
+++ b/src/test/cellEditing.test.ts
@@ -236,6 +236,88 @@ suite('Stable cell editing', () => {
         ]);
     });
 
+    test('preserves exact 64-bit rowid and INTEGER PRIMARY KEY identities', async () => {
+        createDatabase(`
+            CREATE TABLE integer_keys (id INTEGER PRIMARY KEY, value TEXT);
+            INSERT INTO integer_keys VALUES (9223372036854775806, 'integer-key');
+            CREATE TABLE rowid_keys (value TEXT);
+            INSERT INTO rowid_keys(rowid, value) VALUES (9223372036854775805, 'rowid-key');
+        `);
+        await service.openDatabase(databasePath);
+
+        const integerRows = await service.getTableData('integer_keys');
+        assert.strictEqual(integerRows.rowIdentities[0]?.parts[0].value, '9223372036854775806');
+        await service.updateCellData('integer_keys', integerRows.rowIdentities[0]!, 'value', 'updated-integer-key');
+
+        const rowidRows = await service.getTableData('rowid_keys');
+        assert.strictEqual(rowidRows.rowIdentities[0]?.parts[0].value, '9223372036854775805');
+        await service.updateCellData('rowid_keys', rowidRows.rowIdentities[0]!, 'value', 'updated-rowid-key');
+
+        service.closeDatabase();
+        assert.deepStrictEqual(
+            readRows('SELECT CAST(id AS TEXT) AS id, value FROM integer_keys'),
+            [{ id: '9223372036854775806', value: 'updated-integer-key' }]
+        );
+        assert.deepStrictEqual(
+            readRows('SELECT CAST(rowid AS TEXT) AS rowid, value FROM rowid_keys'),
+            [{ rowid: '9223372036854775805', value: 'updated-rowid-key' }]
+        );
+    });
+
+    test('restores committed in-memory state when persistence fails', async () => {
+        createDatabase(`
+            CREATE TABLE records (id INTEGER PRIMARY KEY, value TEXT);
+            INSERT INTO records VALUES (1, 'original');
+        `);
+        await service.openDatabase(databasePath);
+        const data = await service.getTableData('records');
+        (service as any).saveChangesToFile = async () => {
+            throw new Error('forced persistence failure');
+        };
+
+        await assert.rejects(
+            service.updateCellData('records', data.rowIdentities[0]!, 'value', 'must-not-stick'),
+            /forced persistence failure/
+        );
+
+        const afterFailure = await service.getTableData('records');
+        assert.strictEqual(afterFailure.values[0][1], 'original');
+        assert.deepStrictEqual(readRows('SELECT id, value FROM records'), [{ id: 1, value: 'original' }]);
+    });
+
+    test('serializes persistence for concurrent cell edits', async () => {
+        createDatabase(`
+            CREATE TABLE records (id INTEGER PRIMARY KEY, value TEXT);
+            INSERT INTO records VALUES (1, 'one'), (2, 'two');
+        `);
+        await service.openDatabase(databasePath);
+        const data = await service.getTableData('records');
+        const saveChangesToFile = (service as any).saveChangesToFile.bind(service);
+        let activeSaves = 0;
+        let maxActiveSaves = 0;
+        (service as any).saveChangesToFile = async () => {
+            activeSaves++;
+            maxActiveSaves = Math.max(maxActiveSaves, activeSaves);
+            await new Promise(resolve => setTimeout(resolve, 10));
+            try {
+                await saveChangesToFile();
+            } finally {
+                activeSaves--;
+            }
+        };
+
+        await Promise.all([
+            service.updateCellData('records', identityFor(data, 'id', 1), 'value', 'updated-one'),
+            service.updateCellData('records', identityFor(data, 'id', 2), 'value', 'updated-two')
+        ]);
+
+        assert.strictEqual(maxActiveSaves, 1);
+        assert.deepStrictEqual(readRows('SELECT id, value FROM records ORDER BY id'), [
+            { id: 1, value: 'updated-one' },
+            { id: 2, value: 'updated-two' }
+        ]);
+    });
+
     test('rejects stale, ambiguous, and unavailable row identities without persisting changes', async () => {
         createDatabase(`
             CREATE TABLE ambiguous (a TEXT, b TEXT, value TEXT, PRIMARY KEY (a, b));

--- a/src/test/cellEditing.test.ts
+++ b/src/test/cellEditing.test.ts
@@ -78,7 +78,7 @@ suite('Stable cell editing', () => {
         `);
 
         const disk = new SQL.Database(fs.readFileSync(databasePath));
-        const rowidStatement = disk.prepare('SELECT rowid FROM records LIMIT 1 OFFSET ?');
+        const rowidStatement = disk.prepare('SELECT rowid FROM records ORDER BY rowid LIMIT 1 OFFSET ?');
         const idStatement = disk.prepare('SELECT Id FROM records WHERE rowid = ?');
         const oldOffsetTargets = [1, 5].map(offset => {
             const rowid = rowidStatement.get([offset])[0];

--- a/src/test/cellEditing.test.ts
+++ b/src/test/cellEditing.test.ts
@@ -2,14 +2,20 @@ import * as assert from 'assert';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import initSqlJs = require('sql.js');
 import { DatabaseService, EditableTableData, RowIdentity } from '../databaseService';
-
-const BetterSqlite3: any = require('better-sqlite3');
 
 suite('Stable cell editing', () => {
     let tempDir: string;
     let databasePath: string;
     let service: DatabaseService;
+    let SQL: initSqlJs.SqlJsStatic;
+
+    suiteSetup(async () => {
+        SQL = await initSqlJs({
+            locateFile: file => path.join(__dirname, '..', '..', 'node_modules', 'sql.js', 'dist', file)
+        });
+    });
 
     setup(() => {
         tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sqlite-intelliview-cell-edit-'));
@@ -23,16 +29,23 @@ suite('Stable cell editing', () => {
     });
 
     function createDatabase(sql: string): void {
-        const db = new BetterSqlite3(databasePath);
+        const db = new SQL.Database();
         db.exec(sql);
+        fs.writeFileSync(databasePath, Buffer.from(db.export()));
         db.close();
     }
 
     function readRows<T = Record<string, unknown>>(sql: string): T[] {
-        const db = new BetterSqlite3(databasePath, { readonly: true });
+        const db = new SQL.Database(fs.readFileSync(databasePath));
+        const statement = db.prepare(sql);
+        const rows: T[] = [];
         try {
-            return db.prepare(sql).all() as T[];
+            while (statement.step()) {
+                rows.push(statement.getAsObject() as unknown as T);
+            }
+            return rows;
         } finally {
+            statement.free();
             db.close();
         }
     }
@@ -64,11 +77,18 @@ suite('Stable cell editing', () => {
                 ('g', 1, 1, 'one');
         `);
 
-        const disk = new BetterSqlite3(databasePath);
+        const disk = new SQL.Database(fs.readFileSync(databasePath));
+        const rowidStatement = disk.prepare('SELECT rowid FROM records LIMIT 1 OFFSET ?');
+        const idStatement = disk.prepare('SELECT Id FROM records WHERE rowid = ?');
         const oldOffsetTargets = [1, 5].map(offset => {
-            const rowid = disk.prepare('SELECT rowid FROM records LIMIT 1 OFFSET ?').get(offset).rowid;
-            return disk.prepare('SELECT Id FROM records WHERE rowid = ?').get(rowid).Id;
+            const rowid = rowidStatement.get([offset])[0];
+            rowidStatement.reset();
+            const id = idStatement.get([rowid])[0];
+            idStatement.reset();
+            return id;
         });
+        rowidStatement.free();
+        idStatement.free();
         disk.close();
         assert.deepStrictEqual(oldOffsetTargets, [5, 40]);
 

--- a/src/test/cellEditing.test.ts
+++ b/src/test/cellEditing.test.ts
@@ -406,6 +406,41 @@ suite('Stable cell editing', () => {
         ]);
     });
 
+    test('rolls back deletes unless exactly one row matches', async () => {
+        createDatabase(`
+            CREATE TABLE records (id INTEGER PRIMARY KEY, category TEXT, value TEXT);
+            INSERT INTO records VALUES (1, 'duplicate', 'one'), (2, 'duplicate', 'two'), (3, 'unique', 'three');
+        `);
+        await service.openDatabase(databasePath);
+        const saveChangesToFile = (service as any).saveChangesToFile.bind(service);
+        let persistenceAttempts = 0;
+        (service as any).saveChangesToFile = async (databaseState?: Uint8Array) => {
+            persistenceAttempts++;
+            await saveChangesToFile(databaseState);
+        };
+
+        await assert.rejects(
+            service.deleteRow('records', { column: 'category', value: 'duplicate' }),
+            /expected one changed row but SQLite reported 2/
+        );
+        await assert.rejects(
+            service.deleteRow('records', { column: 'id', value: 99 }),
+            /No row was deleted/
+        );
+
+        assert.strictEqual(persistenceAttempts, 0);
+        assert.deepStrictEqual((await service.getTableData('records')).values, [
+            [1, 'duplicate', 'one'],
+            [2, 'duplicate', 'two'],
+            [3, 'unique', 'three']
+        ]);
+        assert.deepStrictEqual(readRows('SELECT id, category, value FROM records ORDER BY id'), [
+            { id: 1, category: 'duplicate', value: 'one' },
+            { id: 2, category: 'duplicate', value: 'two' },
+            { id: 3, category: 'unique', value: 'three' }
+        ]);
+    });
+
     test('serializes persistence for concurrent updates and deletes', async () => {
         createDatabase(`
             CREATE TABLE records (id INTEGER PRIMARY KEY, value TEXT);

--- a/src/test/cellEditing.test.ts
+++ b/src/test/cellEditing.test.ts
@@ -1,0 +1,260 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { DatabaseService, EditableTableData, RowIdentity } from '../databaseService';
+
+const BetterSqlite3: any = require('better-sqlite3');
+
+suite('Stable cell editing', () => {
+    let tempDir: string;
+    let databasePath: string;
+    let service: DatabaseService;
+
+    setup(() => {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sqlite-intelliview-cell-edit-'));
+        databasePath = path.join(tempDir, 'test.sqlite');
+        service = new DatabaseService();
+    });
+
+    teardown(() => {
+        service.closeDatabase();
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    function createDatabase(sql: string): void {
+        const db = new BetterSqlite3(databasePath);
+        db.exec(sql);
+        db.close();
+    }
+
+    function readRows<T = Record<string, unknown>>(sql: string): T[] {
+        const db = new BetterSqlite3(databasePath, { readonly: true });
+        try {
+            return db.prepare(sql).all() as T[];
+        } finally {
+            db.close();
+        }
+    }
+
+    function identityFor(data: EditableTableData, column: string, value: unknown): RowIdentity {
+        const columnIndex = data.columns.indexOf(column);
+        const rowIndex = data.values.findIndex(row => row[columnIndex] === value);
+        assert.ok(rowIndex >= 0, `Expected a row whose ${column} is ${String(value)}`);
+        const identity = data.rowIdentities[rowIndex];
+        assert.ok(identity, 'Expected the row to have a stable identity');
+        return identity;
+    }
+
+    test('reproduces the reported Id 1 to 5 and Id 5 to 40 OFFSET mismatch', async () => {
+        createDatabase(`
+            CREATE TABLE records (
+                record_key TEXT PRIMARY KEY,
+                Id INTEGER,
+                display_order INTEGER,
+                value TEXT
+            );
+            INSERT INTO records VALUES
+                ('a', 99, 0, 'ninety-nine'),
+                ('b', 5, 5, 'five'),
+                ('c', 2, 2, 'two'),
+                ('d', 3, 3, 'three'),
+                ('e', 4, 4, 'four'),
+                ('f', 40, 6, 'forty'),
+                ('g', 1, 1, 'one');
+        `);
+
+        const disk = new BetterSqlite3(databasePath);
+        const oldOffsetTargets = [1, 5].map(offset => {
+            const rowid = disk.prepare('SELECT rowid FROM records LIMIT 1 OFFSET ?').get(offset).rowid;
+            return disk.prepare('SELECT Id FROM records WHERE rowid = ?').get(rowid).Id;
+        });
+        disk.close();
+        assert.deepStrictEqual(oldOffsetTargets, [5, 40]);
+
+        await service.openDatabase(databasePath);
+        const data = await service.getTableData('records');
+        const displayOrderIndex = data.columns.indexOf('display_order');
+        const idIndex = data.columns.indexOf('Id');
+        const visible = data.values
+            .map((row, sourceIndex) => ({ row, identity: data.rowIdentities[sourceIndex] }))
+            .sort((a, b) => Number(a.row[displayOrderIndex]) - Number(b.row[displayOrderIndex]));
+        assert.strictEqual(visible[1].row[idIndex], 1);
+        assert.strictEqual(visible[5].row[idIndex], 5);
+
+        await service.updateCellData('records', visible[1].identity!, 'value', 'selected-one');
+        await service.updateCellData('records', visible[5].identity!, 'value', 'selected-five');
+
+        service.closeDatabase();
+        assert.deepStrictEqual(readRows('SELECT Id, value FROM records WHERE Id IN (1, 5, 40) ORDER BY Id'), [
+            { Id: 1, value: 'selected-one' },
+            { Id: 5, value: 'selected-five' },
+            { Id: 40, value: 'forty' }
+        ]);
+    });
+
+    test('keeps identity attached through first/middle row sorting, filtering, and virtual source ordering', async () => {
+        createDatabase(`
+            CREATE TABLE records (Id INTEGER PRIMARY KEY, value TEXT);
+            INSERT INTO records VALUES (1, 'one'), (5, 'five'), (40, 'forty'), (75, 'seventy-five');
+        `);
+        await service.openDatabase(databasePath);
+        const data = await service.getTableDataPaginated('records', 1, 100);
+
+        const pairedRows = data.values.map((row, index) => ({ row, identity: data.rowIdentities[index] }));
+        const sorted = [...pairedRows].sort((a, b) => Number(b.row[0]) - Number(a.row[0]));
+        const firstVisibleId1 = sorted.find(item => item.row[0] === 1);
+        assert.ok(firstVisibleId1?.identity);
+        await service.updateCellData('records', firstVisibleId1.identity, 'value', 'sorted-one');
+
+        const filtered = pairedRows.filter(item => String(item.row[0]).includes('5'));
+        const middleId5 = filtered.find(item => item.row[0] === 5);
+        assert.ok(middleId5?.identity);
+        await service.updateCellData('records', middleId5.identity, 'value', 'filtered-five');
+
+        const virtualOrder = [3, 0, 2, 1];
+        const virtualVisibleRow = pairedRows[virtualOrder[2]];
+        assert.strictEqual(virtualVisibleRow.row[0], 40);
+        assert.ok(virtualVisibleRow.identity);
+        await service.updateCellData('records', virtualVisibleRow.identity, 'value', 'virtual-forty');
+
+        service.closeDatabase();
+        assert.deepStrictEqual(readRows('SELECT Id, value FROM records ORDER BY Id'), [
+            { Id: 1, value: 'sorted-one' },
+            { Id: 5, value: 'filtered-five' },
+            { Id: 40, value: 'virtual-forty' },
+            { Id: 75, value: 'seventy-five' }
+        ]);
+    });
+
+    test('uses implicit rowid on a later pagination page and leaves neighbouring rows unchanged', async () => {
+        createDatabase(`
+            CREATE TABLE notes (value TEXT);
+            INSERT INTO notes(value) VALUES ('one'), ('two'), ('three'), ('four'), ('five'), ('six');
+        `);
+        await service.openDatabase(databasePath);
+        const secondPage = await service.getTableDataPaginated('notes', 2, 2);
+
+        assert.strictEqual(secondPage.rowIdentities[0]?.kind, 'rowid');
+        assert.deepStrictEqual(secondPage.values.map(row => row[0]), ['three', 'four']);
+        await service.updateCellData('notes', secondPage.rowIdentities[0]!, 'value', 'page-two-first');
+
+        service.closeDatabase();
+        assert.deepStrictEqual(readRows('SELECT rowid, value FROM notes ORDER BY rowid'), [
+            { rowid: 1, value: 'one' },
+            { rowid: 2, value: 'two' },
+            { rowid: 3, value: 'page-two-first' },
+            { rowid: 4, value: 'four' },
+            { rowid: 5, value: 'five' },
+            { rowid: 6, value: 'six' }
+        ]);
+    });
+
+    test('supports text and composite primary keys, WITHOUT ROWID, and primary-key edits', async () => {
+        createDatabase(`
+            CREATE TABLE text_keys (code TEXT PRIMARY KEY, value TEXT);
+            INSERT INTO text_keys VALUES ('alpha', 'A'), ('beta', 'B');
+            CREATE TABLE memberships (
+                account TEXT,
+                region TEXT,
+                value TEXT,
+                PRIMARY KEY (account, region)
+            ) WITHOUT ROWID;
+            INSERT INTO memberships VALUES ('acct', 'eu', 'old'), ('acct', 'us', 'untouched');
+        `);
+        await service.openDatabase(databasePath);
+
+        const textRows = await service.getTableData('text_keys');
+        const originalTextIdentity = identityFor(textRows, 'code', 'alpha');
+        const keyEdit = await service.updateCellData('text_keys', originalTextIdentity, 'code', 'alpha-renamed');
+        await service.updateCellData('text_keys', keyEdit.identity, 'value', 'renamed-value');
+
+        const compositeRows = await service.getTableData('memberships');
+        assert.strictEqual(compositeRows.rowIdentities[0]?.parts.length, 2);
+        const euIdentity = identityFor(compositeRows, 'region', 'eu');
+        await service.updateCellData('memberships', euIdentity, 'value', 'composite-updated');
+
+        service.closeDatabase();
+        assert.deepStrictEqual(readRows('SELECT code, value FROM text_keys ORDER BY code'), [
+            { code: 'alpha-renamed', value: 'renamed-value' },
+            { code: 'beta', value: 'B' }
+        ]);
+        assert.deepStrictEqual(readRows('SELECT account, region, value FROM memberships ORDER BY region'), [
+            { account: 'acct', region: 'eu', value: 'composite-updated' },
+            { account: 'acct', region: 'us', value: 'untouched' }
+        ]);
+    });
+
+    test('binds quotes, Unicode, and null values without changing the selected identity', async () => {
+        createDatabase(`
+            CREATE TABLE content (id INTEGER PRIMARY KEY, value TEXT);
+            INSERT INTO content VALUES (1, 'first'), (5, 'second'), (40, 'third');
+            CREATE TABLE "odd""table" ("key""part" TEXT PRIMARY KEY, "value""text" TEXT);
+            INSERT INTO "odd""table" VALUES ('quoted-key', 'old');
+        `);
+        await service.openDatabase(databasePath);
+        const data = await service.getTableData('content');
+
+        await service.updateCellData('content', identityFor(data, 'id', 1), 'value', "O'Reilly — 雪");
+        await service.updateCellData('content', identityFor(data, 'id', 5), 'value', null);
+        const quoted = await service.getTableData('odd"table');
+        await service.updateCellData(
+            'odd"table',
+            identityFor(quoted, 'key"part', 'quoted-key'),
+            'value"text',
+            'safe " identifier'
+        );
+
+        service.closeDatabase();
+        assert.deepStrictEqual(readRows('SELECT id, value FROM content ORDER BY id'), [
+            { id: 1, value: "O'Reilly — 雪" },
+            { id: 5, value: null },
+            { id: 40, value: 'third' }
+        ]);
+        assert.deepStrictEqual(readRows('SELECT "value""text" AS value FROM "odd""table"'), [
+            { value: 'safe " identifier' }
+        ]);
+    });
+
+    test('rejects stale, ambiguous, and unavailable row identities without persisting changes', async () => {
+        createDatabase(`
+            CREATE TABLE ambiguous (a TEXT, b TEXT, value TEXT, PRIMARY KEY (a, b));
+            INSERT INTO ambiguous VALUES (NULL, 'same', 'first'), (NULL, 'same', 'second');
+            CREATE TABLE shadowed (rowid TEXT, _rowid_ TEXT, oid TEXT, value TEXT);
+            INSERT INTO shadowed VALUES ('r', 'u', 'o', 'unchanged');
+            CREATE VIEW ambiguous_view AS SELECT * FROM ambiguous;
+        `);
+        await service.openDatabase(databasePath);
+
+        const ambiguous = await service.getTableData('ambiguous');
+        await assert.rejects(
+            service.updateCellData('ambiguous', ambiguous.rowIdentities[0]!, 'value', 'must-rollback'),
+            /expected one changed row but SQLite reported 2/
+        );
+
+        const staleIdentity: RowIdentity = {
+            kind: 'primaryKey',
+            parts: [{ column: 'a', value: 'missing' }, { column: 'b', value: 'missing' }]
+        };
+        await assert.rejects(
+            service.updateCellData('ambiguous', staleIdentity, 'value', 'must-not-write'),
+            /No row was updated/
+        );
+
+        const shadowed = await service.getTableData('shadowed');
+        assert.strictEqual(shadowed.editable, false);
+        assert.ok(shadowed.rowIdentities.every(identity => identity === null));
+        assert.match(shadowed.editError || '', /rowid aliases are shadowed/);
+
+        const view = await service.getTableData('ambiguous_view');
+        assert.strictEqual(view.editable, false);
+        assert.match(view.editError || '', /Views cannot be edited safely/);
+
+        service.closeDatabase();
+        assert.deepStrictEqual(readRows('SELECT value FROM ambiguous ORDER BY rowid'), [
+            { value: 'first' },
+            { value: 'second' }
+        ]);
+        assert.deepStrictEqual(readRows('SELECT value FROM shadowed'), [{ value: 'unchanged' }]);
+    });
+});

--- a/src/test/cellEditing.test.ts
+++ b/src/test/cellEditing.test.ts
@@ -133,7 +133,8 @@ suite('Stable cell editing', () => {
         await service.updateCellData('records', middleId5.identity, 'value', 'filtered-five');
 
         const virtualOrder = [3, 0, 2, 1];
-        const virtualVisibleRow = pairedRows[virtualOrder[2]];
+        const virtualRows = virtualOrder.map(sourceIndex => pairedRows[sourceIndex]);
+        const virtualVisibleRow = virtualRows[2];
         assert.strictEqual(virtualVisibleRow.row[0], 40);
         assert.ok(virtualVisibleRow.identity);
         await service.updateCellData('records', virtualVisibleRow.identity, 'value', 'virtual-forty');
@@ -186,6 +187,25 @@ suite('Stable cell editing', () => {
             firstPage.rowIdentities.map(identity => identity?.parts[0].value),
             ['alpha', 'bravo']
         );
+    });
+
+    test('caps read limits and falls back for unsafe integer limits', async () => {
+        createDatabase(`
+            CREATE TABLE many_rows (id INTEGER PRIMARY KEY);
+            WITH RECURSIVE sequence(id) AS (
+                SELECT 1
+                UNION ALL
+                SELECT id + 1 FROM sequence WHERE id < 100001
+            )
+            INSERT INTO many_rows SELECT id FROM sequence;
+        `);
+        await service.openDatabase(databasePath);
+
+        const capped = await service.getTableData('many_rows', 100001);
+        const unsafe = await service.getTableData('many_rows', Number.MAX_SAFE_INTEGER + 1);
+
+        assert.strictEqual(capped.values.length, 100000);
+        assert.strictEqual(unsafe.values.length, 1000);
     });
 
     test('supports text and composite primary keys, WITHOUT ROWID, and primary-key edits', async () => {
@@ -383,6 +403,16 @@ suite('Stable cell editing', () => {
         assert.strictEqual(shadowed.editable, false);
         assert.ok(shadowed.rowIdentities.every(identity => identity === null));
         assert.match(shadowed.editError || '', /rowid aliases are shadowed/);
+        const forgedShadowedIdentity: RowIdentity = {
+            kind: 'rowid',
+            parts: [{ column: 'rowid', value: 'r' }]
+        };
+        await assert.rejects(
+            service.updateCellData('shadowed', forgedShadowedIdentity, 'value', 'must-not-write'),
+            /rowid aliases are shadowed/
+        );
+        const shadowedAfterUpdate = await service.getTableData('shadowed');
+        assert.strictEqual(shadowedAfterUpdate.values[0][3], 'unchanged');
 
         const view = await service.getTableData('stable_view');
         assert.strictEqual(view.editable, false);

--- a/src/test/vscodeMock.ts
+++ b/src/test/vscodeMock.ts
@@ -1,0 +1,27 @@
+import Module = require('module');
+
+const moduleWithLoader = Module as unknown as {
+    _load: (request: string, parent: unknown, isMain: boolean) => unknown;
+};
+const originalLoad = moduleWithLoader._load;
+
+moduleWithLoader._load = function loadWithVscodeMock(request: string, parent: unknown, isMain: boolean): unknown {
+    if (request === 'vscode') {
+        return {
+            workspace: {
+                getConfiguration: () => ({
+                    get: (_name: string, defaultValue: unknown) => defaultValue
+                })
+            },
+            window: {
+                showWarningMessage: () => undefined,
+                showErrorMessage: () => undefined,
+                showInformationMessage: () => undefined
+            },
+            env: {
+                appName: 'SQLite IntelliView Test'
+            }
+        };
+    }
+    return originalLoad.call(this, request, parent, isMain);
+};

--- a/src/webviewMessages.ts
+++ b/src/webviewMessages.ts
@@ -1,3 +1,5 @@
+import type { RowIdentity } from './databaseService';
+
 export type WalCheckpointModeSetting = 'full' | 'passive' | 'off';
 
 export interface WebviewSettingsPayload {
@@ -42,7 +44,8 @@ export interface GetTableDataMessage {
 export interface UpdateCellDataMessage {
     type: 'updateCellData';
     tableName: string;
-    rowIndex: number;
+    requestId: string;
+    rowIdentity: RowIdentity;
     columnName: string;
     newValue: unknown;
     key?: string;
@@ -165,6 +168,20 @@ function hasDefinedProperty(value: Record<string, unknown>, key: string): boolea
     return Object.prototype.hasOwnProperty.call(value, key) && value[key] !== undefined;
 }
 
+function isRowIdentity(value: unknown): value is RowIdentity {
+    if (!isRecord(value) || (value.kind !== 'primaryKey' && value.kind !== 'rowid') || !Array.isArray(value.parts)) {
+        return false;
+    }
+    if (value.parts.length === 0) {
+        return false;
+    }
+    return value.parts.every(part => (
+        isRecord(part) &&
+        isString(part.column) &&
+        hasDefinedProperty(part, 'value')
+    ));
+}
+
 function isExtensionMessageType(type: unknown): type is ExtensionToWebviewMessage['type'] {
     return typeof type === 'string' && EXTENSION_TO_WEBVIEW_TYPES.has(type as ExtensionToWebviewMessage['type']);
 }
@@ -272,7 +289,8 @@ export function isWebviewToExtensionMessage(value: unknown): value is WebviewToE
         case 'updateCellData':
             return (
                 isString(value.tableName) &&
-                typeof value.rowIndex === 'number' &&
+                isString(value.requestId) &&
+                isRowIdentity(value.rowIdentity) &&
                 isString(value.columnName) &&
                 hasDefinedProperty(value, 'newValue') &&
                 isOptionalString(value.key)

--- a/src/webviewMessages.ts
+++ b/src/webviewMessages.ts
@@ -168,6 +168,15 @@ function hasDefinedProperty(value: Record<string, unknown>, key: string): boolea
     return Object.prototype.hasOwnProperty.call(value, key) && value[key] !== undefined;
 }
 
+function isSQLiteValue(value: unknown): boolean {
+    return (
+        value === null ||
+        typeof value === 'string' ||
+        (typeof value === 'number' && Number.isFinite(value)) ||
+        value instanceof Uint8Array
+    );
+}
+
 function isRowIdentity(value: unknown): value is RowIdentity {
     if (!isRecord(value) || (value.kind !== 'primaryKey' && value.kind !== 'rowid') || !Array.isArray(value.parts)) {
         return false;
@@ -178,7 +187,8 @@ function isRowIdentity(value: unknown): value is RowIdentity {
     return value.parts.every(part => (
         isRecord(part) &&
         isString(part.column) &&
-        hasDefinedProperty(part, 'value')
+        hasDefinedProperty(part, 'value') &&
+        isSQLiteValue(part.value)
     ));
 }
 

--- a/src/webviewMessages.ts
+++ b/src/webviewMessages.ts
@@ -173,7 +173,13 @@ function isSQLiteValue(value: unknown): boolean {
         value === null ||
         typeof value === 'string' ||
         (typeof value === 'number' && Number.isFinite(value)) ||
-        value instanceof Uint8Array
+        value instanceof Uint8Array ||
+        (
+            isRecord(value) &&
+            value.type === 'blob' &&
+            typeof value.base64 === 'string' &&
+            Buffer.from(value.base64, 'base64').toString('base64') === value.base64
+        )
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes a critical data-integrity bug where editing a grid cell could persist the value to a different SQLite record.

This PR:

- Preserves stable database identity from row loading through update execution.
- Supports integer, text, and composite primary keys.
- Supports `WITHOUT ROWID` tables and ordinary tables with an available SQLite `rowid`.
- Makes tables without a safe unique identity read-only.
- Validates that exactly one row changed before reporting success.
- Refreshes row data and identity together after writes and external changes.

## Root cause

The webview previously sent a presentation `rowIndex` to the extension. The extension then resolved it using an independent query:

```sql
SELECT rowid
FROM "<table>"
LIMIT 1 OFFSET <rowIndex>
```

This query did not have a guaranteed ordering relationship with the query used to populate the grid. Sorting, filtering, pagination, virtual scrolling, or SQLite choosing a different scan plan could therefore resolve the offset to another record.

This explains the reported behaviour:

- Editing `Id = 1` resolved to the row containing `Id = 5`.
- Editing `Id = 5` resolved to the row containing `Id = 40`.

The subsequent update was correctly parameterized, but it received the wrong `rowid`.

## Solution

Each loaded row now carries a stable identity independently from its visual position.

Identity selection follows this order:

1. The table’s declared primary key, in declared key order.
2. An available SQLite `rowid`, `_rowid_`, or `oid`.
3. If no safe identity exists, editing is disabled.

Updates are now logically equivalent to:

```sql
UPDATE "<table>"
SET "<edited-column>" = ?
WHERE "<identity-column>" IS ?
```

All values are bound parameters and all identifiers are safely quoted.

Primary-key edits use the original key in the `WHERE` clause and refresh the row identity after saving.

## Safety measures

- The supplied identity is validated against the current table schema.
- Visual row indexes no longer cross the persistence boundary.
- Updates run inside a transaction.
- Zero changed rows produce a stale-record error.
- More than one changed row triggers a rollback and critical failure.
- Success is shown only when SQLite reports exactly one changed row.
- External refreshes replace row data and identities atomically.
- Views and tables without safe identity are visibly read-only.

## Testing

Added real temporary SQLite integration coverage for:

- The exact `Id = 1`, `5`, and `40` regression.
- First and middle visible rows.
- Sorting and filtering/search ordering.
- Later pagination pages.
- Virtual indexes differing from source indexes.
- Integer and text primary keys.
- Composite primary keys.
- Primary-key edits.
- Implicit `rowid`.
- `WITHOUT ROWID`.
- Quotes, Unicode, nulls, and quoted identifiers.
- Stale and ambiguous identities.
- Tables without safe row identity.
- Neighbouring-row regression assertions.
- Closing and reopening the database to verify persisted results.

## Validation

- Real SQLite integration suite: 6 passing.
- `npm run check-types`
- `npm run build`
- `npm run lint` — no errors; existing generated JavaScript warnings remain.
- JavaScript syntax checks.
- `git diff --check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cell editing targeting the wrong row after sort/filter/pagination/virtual scrolling by using stable row identities and request-based success/error handling (including correct NULL rendering).
  * Improved reliability of table refreshes and hardened incremental table data updates for both non-virtual and virtual views.
* **New Features**
  * Editing is now automatically disabled for tables where a safe stable row identity can’t be derived (views remain read-only, with a clearer reason when available).
  * Updated the cell-edit messaging contract to use request IDs and structured row identities.
* **Tests**
  * Added integration coverage for stable identity editing, rollback/persistence semantics, and concurrent update/delete scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->