### PR TITLE
Add multi-row selection with checkboxes, batch delete/export

### DIFF
--- a/media/context-menu.js
+++ b/media/context-menu.js
@@ -704,7 +704,7 @@ function copyColumnData() {
     tableWrapper && tableWrapper.__virtualTableState;
 
   // Get column header
-  const header = table.querySelector(`thead th:nth-child(${columnIndex + 1})`);
+  const header = table.querySelector(`thead th:nth-child(${columnIndex + 2})`);
   const headerText = header
     ? getColumnHeaderText(header)
     : `Column ${columnIndex + 1}`;
@@ -730,7 +730,7 @@ function copyColumnData() {
   } else {
     const rows = table.querySelectorAll("tbody tr");
     rows.forEach((row) => {
-      const cell = row.cells[columnIndex];
+      const cell = row.querySelector(`td[data-column="${columnIndex}"]`);
       if (cell) {
         const res = getCellCopyValue(cell, { mode: "tsv" });
         hadLargeBlob = hadLargeBlob || res.hadLargeBlob;
@@ -2719,7 +2719,7 @@ function highlightForeignKeyTarget(tableWrapper) {
   let targetRow = null;
 
   for (const row of rows) {
-    const cell = row.cells[targetColumnIndex];
+    const cell = row.querySelector(`td[data-column="${targetColumnIndex}"]`);
     if (cell) {
       const cellValue = getCellDisplayValue
         ? getCellDisplayValue(cell)

--- a/media/context-menu.js
+++ b/media/context-menu.js
@@ -2673,7 +2673,7 @@ function highlightForeignKeyTarget(tableWrapper) {
       ? getColumnHeaderText(headers[i])
       : headers[i].textContent.trim();
     if (headerText === foreignKeyInfo.referencedColumn) {
-      targetColumnIndex = i;
+      targetColumnIndex = parseInt(headers[i].getAttribute("data-column") || "-1", 10);
       break;
     }
   }

--- a/media/css/30-components/tables.css
+++ b/media/css/30-components/tables.css
@@ -88,6 +88,64 @@
   background: var(--sqlite-table-row-hover-background) !important;
   border-left: 3px solid var(--vscode-focusBorder);
 }
+.data-table tbody tr.selected {
+  background: color-mix(
+    in srgb,
+    var(--vscode-list-activeSelectionBackground) 60%,
+    var(--sqlite-table-row-background)
+  ) !important;
+  border-left: 3px solid var(--vscode-list-activeSelectionBackground);
+  outline: 1px solid var(--vscode-list-activeSelectionBackground);
+  outline-offset: -1px;
+}
+.data-table tbody tr.selected:nth-child(even) {
+  background: color-mix(
+    in srgb,
+    var(--vscode-list-activeSelectionBackground) 60%,
+    var(--sqlite-table-row-alt-background)
+  ) !important;
+}
+.data-table tbody tr.selected:hover {
+  background: var(--vscode-list-activeSelectionBackground) !important;
+}
+
+/* Checkbox column */
+.checkbox-col {
+  width: 32px !important;
+  min-width: 32px !important;
+  max-width: 32px !important;
+}
+.checkbox-th {
+  width: 32px;
+  min-width: 32px;
+  max-width: 32px;
+  text-align: center;
+  padding: 4px !important;
+  border-right: 1px solid var(--vscode-panel-border);
+}
+.checkbox-th .select-all-checkbox {
+  margin: 0;
+  cursor: pointer;
+  display: block;
+}
+.checkbox-cell {
+  width: 32px;
+  min-width: 32px;
+  max-width: 32px;
+  text-align: center;
+  padding: 4px !important;
+  overflow: visible;
+  border-right: 1px solid var(--vscode-panel-border);
+}
+.checkbox-cell input[type="checkbox"] {
+  margin: 0;
+  cursor: pointer;
+  display: block;
+}
+.data-table tbody tr:hover .checkbox-cell {
+  background: var(--sqlite-table-row-hover-background);
+}
+
 .data-table tr:nth-child(even) {
   background: var(--sqlite-table-row-alt-background);
 }
@@ -335,6 +393,17 @@
 .table-action-btn:active {
   transform: translateY(0);
   box-shadow: none;
+}
+.table-action-btn-selection {
+  /* Hidden by inline style; shown dynamically by updateSelectedUI */
+}
+.table-action-btn-danger {
+  background: var(--vscode-errorForeground) !important;
+  border-color: var(--vscode-errorForeground) !important;
+  color: var(--vscode-button-foreground) !important;
+}
+.table-action-btn-danger:hover {
+  background: color-mix(in srgb, var(--vscode-errorForeground) 80%, white) !important;
 }
 
 /* ===== PAGINATION CONTROLS ===== */

--- a/media/css/30-components/tables.css
+++ b/media/css/30-components/tables.css
@@ -394,8 +394,11 @@
   transform: translateY(0);
   box-shadow: none;
 }
-.table-action-btn-selection {
-  /* Hidden by inline style; shown dynamically by updateSelectedUI */
+.table-action-btn-selection.hidden {
+  display: none !important;
+}
+.table-action-btn-selection:not(.hidden) {
+  display: inline-flex;
 }
 .table-action-btn-danger {
   background: var(--vscode-errorForeground) !important;
@@ -403,7 +406,7 @@
   color: var(--vscode-button-foreground) !important;
 }
 .table-action-btn-danger:hover {
-  background: color-mix(in srgb, var(--vscode-errorForeground) 80%, white) !important;
+  background: color-mix(in srgb, var(--vscode-errorForeground) 80%, var(--vscode-button-foreground)) !important;
 }
 
 /* ===== PAGINATION CONTROLS ===== */

--- a/media/events.js
+++ b/media/events.js
@@ -2458,6 +2458,10 @@ function initializeTableEvents(tableWrapper) {
         if (typeof filterTable !== "undefined") {
           filterTable(tableWrapper, searchTerm);
         }
+        // Clear multi-row selection when search changes
+        if (typeof clearSelection === "function") {
+          clearSelection(tableWrapper);
+        }
         const tableKey = tableWrapper.getAttribute("data-table");
         if (tableKey && typeof window.setTabViewState === "function") {
           window.setTabViewState(
@@ -2668,14 +2672,142 @@ function initializeTableEvents(tableWrapper) {
         }
       });
     }
-    // Export button
+    // Export button (all visible)
     const exportBtn = tableWrapper.querySelector('[data-action="export"]');
     if (exportBtn) {
       exportBtn.addEventListener("click", (e) => {
         e.preventDefault();
-        const tableWrapper = e.target.closest(".enhanced-table-wrapper");
+        const wrapper = e.target.closest(".enhanced-table-wrapper");
         if (typeof exportTableData !== "undefined") {
-          exportTableData(tableWrapper);
+          exportTableData(wrapper, { onlySelected: false });
+        }
+      });
+    }
+
+    // Export selected button
+    const exportSelectedBtn = tableWrapper.querySelector(
+      '[data-action="export-selected"]'
+    );
+    if (exportSelectedBtn) {
+      exportSelectedBtn.addEventListener("click", (e) => {
+        e.preventDefault();
+        const wrapper = e.target.closest(".enhanced-table-wrapper");
+        if (typeof exportTableData !== "undefined") {
+          exportTableData(wrapper, { onlySelected: true });
+        }
+      });
+    }
+
+    // Delete selected button
+    const deleteSelectedBtn = tableWrapper.querySelector(
+      '[data-action="delete-selected"]'
+    );
+    if (deleteSelectedBtn) {
+      deleteSelectedBtn.addEventListener("click", (e) => {
+        e.preventDefault();
+        const wrapper = e.target.closest(".enhanced-table-wrapper");
+        if (typeof deleteSelectedRows !== "undefined") {
+          deleteSelectedRows(wrapper);
+        }
+      });
+    }
+
+    // Multi-row selection via row click or checkbox
+    if (tableWrapper.getAttribute("data-selection-delegated") !== "true") {
+      tableWrapper.setAttribute("data-selection-delegated", "true");
+
+      tableWrapper.addEventListener("click", (e) => {
+        const target = e.target instanceof Element ? e.target : null;
+        if (!target) return;
+
+        // Ignore clicks on interactive elements (but NOT checkboxes — handle those via change event)
+        if (
+          target.closest(
+            "button, select, textarea, a, .resize-handle, .cell-editing-controls, th, .sortable-header, .pagination-btn, .page-input, .page-size-select"
+          )
+        ) {
+          return;
+        }
+
+        const row = target.closest("tr.resizable-row");
+        if (!row) return;
+
+        const globalIndex = parseInt(
+          row.getAttribute("data-row-index") || "",
+          10
+        );
+        if (!Number.isFinite(globalIndex)) return;
+
+        const wrapper = row.closest(".enhanced-table-wrapper");
+        if (!wrapper) return;
+
+        if (typeof toggleRowSelection === "function") {
+          toggleRowSelection(wrapper, globalIndex);
+        }
+      });
+
+      // Individual checkbox toggle
+      tableWrapper.addEventListener("change", (e) => {
+        const target = e.target instanceof Element ? e.target : null;
+        if (!target) return;
+
+        const cb = target.closest(".row-select-checkbox");
+        if (!cb) return;
+
+        const globalIndex = parseInt(
+          cb.getAttribute("data-global-index") || "",
+          10
+        );
+        if (!Number.isFinite(globalIndex)) return;
+
+        const wrapper = cb.closest(".enhanced-table-wrapper");
+        if (!wrapper) return;
+
+        // Sync the selection store with the checkbox state
+        const sel = typeof getSelectionStore === "function" ? getSelectionStore(wrapper) : null;
+        if (!sel) return;
+
+        if (cb.checked) {
+          sel.add(globalIndex);
+        } else {
+          sel.delete(globalIndex);
+        }
+        if (typeof updateSelectedUI === "function") {
+          updateSelectedUI(wrapper);
+        }
+      });
+
+      // Select-all checkbox
+      tableWrapper.addEventListener("change", (e) => {
+        const target = e.target instanceof Element ? e.target : null;
+        if (!target) return;
+
+        const cb = target.closest(".select-all-checkbox");
+        if (!cb) return;
+
+        const wrapper = cb.closest(".enhanced-table-wrapper");
+        if (!wrapper) return;
+
+        const table = wrapper.querySelector(".data-table");
+        if (!table) return;
+
+        const sel = typeof getSelectionStore === "function" ? getSelectionStore(wrapper) : null;
+        if (!sel) return;
+
+        const visibleRows = table.querySelectorAll("tr.resizable-row");
+        if (cb.checked) {
+          visibleRows.forEach((row) => {
+            const idx = parseInt(row.getAttribute("data-row-index") || "", 10);
+            if (Number.isFinite(idx)) sel.add(idx);
+          });
+        } else {
+          visibleRows.forEach((row) => {
+            const idx = parseInt(row.getAttribute("data-row-index") || "", 10);
+            if (Number.isFinite(idx)) sel.delete(idx);
+          });
+        }
+        if (typeof updateSelectedUI === "function") {
+          updateSelectedUI(wrapper);
         }
       });
     }
@@ -3152,6 +3284,47 @@ function handleCellUpdateError(message) {
 function handleDeleteRowSuccess(message) {
   const { tableName, rowId } = message;
 
+  // Batch delete handler: refresh table and clear selection
+  if (Array.isArray(rowId) && rowId.length > 1) {
+    if (typeof showDeleteSuccess === "function") showDeleteSuccess();
+    // Clear any stale selection state
+    const wrapper = document.querySelector(
+      `.enhanced-table-wrapper[data-table="${tableName}"]`,
+    );
+    if (wrapper && typeof clearSelection === "function") {
+      clearSelection(wrapper);
+    }
+    // Trigger a data refresh for the current page
+    const state =
+      typeof getCurrentState === "function" ? getCurrentState() : {};
+    const vs =
+      wrapper &&
+      /** @type {any} */ (wrapper).__virtualTableState;
+    const page = vs ? parseInt(wrapper.getAttribute("data-current-page") || "1", 10) : 1;
+    const pageSize = vs ? parseInt(wrapper.getAttribute("data-page-size") || "100", 10) : 100;
+    if (
+      tableName &&
+      window.vscode &&
+      typeof window.vscode.postMessage === "function"
+    ) {
+      window.vscode.postMessage({
+        type: "getTableData",
+        tableName: tableName,
+        key: (state && state.encryptionKey) || "",
+        page,
+        pageSize,
+      });
+    }
+    if (window.debug) {
+      window.debug.debug(
+        `[Events] Batch delete successful for ${tableName}: ${rowId.length} rows`,
+      );
+    }
+    // Skip single-row handler for batches
+    return;
+  }
+
+  // Single-row delete: delegate to context-menu.js handler
   if (
     typeof window !== "undefined" &&
     typeof (/** @type {any} */ (window).handleDeleteSuccess) === "function"
@@ -3706,10 +3879,12 @@ function handleTableDataDelta({
           }
         });
       }
-      // Patch each cell in the new row
+      // Patch each cell in the new row (skip checkbox cell, use data-column attribute)
       if (newRow) {
-        Array.from(newRow.children).forEach((cell, idx) => {
-          const colName = columns[idx];
+        newRow.querySelectorAll("td[data-column]").forEach((cell) => {
+          const colIdx = parseInt(cell.getAttribute("data-column") || "", 10);
+          if (!Number.isFinite(colIdx) || colIdx < 0) return;
+          const colName = columns[colIdx];
           // Always set data-column-name for robust context menu detection
           if (colName) {
             cell.setAttribute("data-column-name", colName);

--- a/media/events.js
+++ b/media/events.js
@@ -3747,6 +3747,10 @@ function handleTableDataDelta({
     if (typeof window.refreshVirtualTable === "function") {
       window.refreshVirtualTable(wrapper);
     }
+    if ((inserts.length > 0 || deletes.length > 0) &&
+        typeof clearSelection === "function") {
+        clearSelection(wrapper);
+    }
     // Reconcile selection: remove stale global indices for deleted rows
     if (Array.isArray(stash?.rowIdentities)) {
       const sel = typeof getSelectionStore === "function" ? getSelectionStore(wrapper) : null;

--- a/media/events.js
+++ b/media/events.js
@@ -2754,8 +2754,9 @@ function initializeTableEvents(tableWrapper) {
         const cb = target.closest(".row-select-checkbox");
         if (!cb) return;
 
+        const row = cb.closest("tr.resizable-row");
         const globalIndex = parseInt(
-          cb.getAttribute("data-global-index") || "",
+          row?.getAttribute("data-row-index") || "",
           10
         );
         if (!Number.isFinite(globalIndex)) return;
@@ -3663,6 +3664,12 @@ function handleTableDataDelta({
 
     const toLocal = (globalRowIndex) => globalRowIndex - pageStart;
 
+    // Get stash to keep rowIdentities in sync with pageData
+    const tableId = wrapper.getAttribute("data-table-id") || wrapper.dataset.tableId || "";
+    const stash = (typeof window.__tableDataStash !== "undefined" && window.__tableDataStash instanceof Map)
+      ? window.__tableDataStash.get(tableId) || null
+      : null;
+
     // Deletes are indices in the OLD page; apply from bottom to top.
     const deleteLocals = deletes
       .map((rowIndex) => toLocal(rowIndex))
@@ -3673,6 +3680,9 @@ function handleTableDataDelta({
       .sort((a, b) => b - a);
     deleteLocals.forEach((local) => {
       vs.pageData.splice(local, 1);
+      if (Array.isArray(stash?.rowIdentities)) {
+        stash.rowIdentities.splice(local, 1);
+      }
     });
 
     // Inserts are indices in the NEW page; apply from top to bottom.
@@ -3692,6 +3702,9 @@ function handleTableDataDelta({
     insertLocals.forEach(({ local, rowData }) => {
       const clamped = Math.max(0, Math.min(vs.pageData.length, local));
       vs.pageData.splice(clamped, 0, rowData);
+      if (Array.isArray(stash?.rowIdentities)) {
+        stash.rowIdentities.splice(clamped, 0, null);
+      }
     });
 
     // Updates are indices in the NEW page.
@@ -3734,6 +3747,24 @@ function handleTableDataDelta({
     if (typeof window.refreshVirtualTable === "function") {
       window.refreshVirtualTable(wrapper);
     }
+    // Reconcile selection: remove stale global indices for deleted rows
+    if (Array.isArray(stash?.rowIdentities)) {
+      const sel = typeof getSelectionStore === "function" ? getSelectionStore(wrapper) : null;
+      if (sel && sel.size > 0) {
+        const validIds = new Set();
+        stash.rowIdentities.forEach((id) => {
+          if (id) validIds.add(JSON.stringify(id));
+        });
+        for (const gIdx of sel) {
+          const local = gIdx - pageStart;
+          const id = stash.rowIdentities[local];
+          if (!id || !validIds.has(JSON.stringify(id))) {
+            sel.delete(gIdx);
+          }
+        }
+        if (typeof updateSelectedUI === "function") updateSelectedUI(wrapper);
+      }
+    }
     return;
   }
 
@@ -3744,6 +3775,13 @@ function handleTableDataDelta({
     }
     return;
   }
+
+  // Get stash for syncing rowIdentities with DOM row order
+  const tableId = wrapper.getAttribute("data-table-id") || wrapper.dataset.tableId || "";
+  const domStash = (typeof window.__tableDataStash !== "undefined" && window.__tableDataStash instanceof Map)
+    ? window.__tableDataStash.get(tableId) || null
+    : null;
+  const startIndex = parseInt(wrapper.getAttribute("data-start-index") || "0", 10) || 0;
 
   //–– 1) APPLY UPDATES ––
   updates.forEach(({ rowIndex, rowData }) => {
@@ -3789,6 +3827,13 @@ function handleTableDataDelta({
           }
         }
       });
+      // Keep stash rowIdentities aligned with the bumped indices
+      if (Array.isArray(domStash?.rowIdentities)) {
+        const insLocal = rowIndex - startIndex;
+        if (insLocal >= 0 && insLocal <= domStash.rowIdentities.length) {
+          domStash.rowIdentities.splice(insLocal, 0, null);
+        }
+      }
       // Use renderTableRows to generate the new row HTML, but robustly patch FK cells after creation
       let columns = Array.from(wrapper.querySelectorAll("thead th[data-column-name]")).map((th) =>
         th.getAttribute("data-column-name"),
@@ -3942,6 +3987,14 @@ function handleTableDataDelta({
         return;
       }
       row.remove();
+      // Keep stash rowIdentities aligned with the removed row
+      if (Array.isArray(domStash?.rowIdentities)) {
+        const delLocal = rowIndex - startIndex;
+        if (delLocal >= 0 && delLocal < domStash.rowIdentities.length) {
+          domStash.rowIdentities.splice(delLocal, 1);
+        }
+      }
+
       // decrement all > rowIndex
       Array.from(tbody.querySelectorAll("tr")).forEach((r) => {
         const idxAttr = r.getAttribute("data-row-index");

--- a/media/events.js
+++ b/media/events.js
@@ -2794,7 +2794,9 @@ function initializeTableEvents(tableWrapper) {
         const sel = typeof getSelectionStore === "function" ? getSelectionStore(wrapper) : null;
         if (!sel) return;
 
-        const visibleRows = table.querySelectorAll("tr.resizable-row");
+        const visibleRows = table.querySelectorAll(
+          "tr.resizable-row:not([style*='display: none'])"
+        );
         if (cb.checked) {
           visibleRows.forEach((row) => {
             const idx = parseInt(row.getAttribute("data-row-index") || "", 10);
@@ -3285,7 +3287,7 @@ function handleDeleteRowSuccess(message) {
   const { tableName, rowId } = message;
 
   // Batch delete handler: refresh table and clear selection
-  if (Array.isArray(rowId) && rowId.length > 1) {
+  if (Array.isArray(rowId) && rowId.length >= 1) {
     if (typeof showDeleteSuccess === "function") showDeleteSuccess();
     // Clear any stale selection state
     const wrapper = document.querySelector(
@@ -3297,11 +3299,8 @@ function handleDeleteRowSuccess(message) {
     // Trigger a data refresh for the current page
     const state =
       typeof getCurrentState === "function" ? getCurrentState() : {};
-    const vs =
-      wrapper &&
-      /** @type {any} */ (wrapper).__virtualTableState;
-    const page = vs ? parseInt(wrapper.getAttribute("data-current-page") || "1", 10) : 1;
-    const pageSize = vs ? parseInt(wrapper.getAttribute("data-page-size") || "100", 10) : 100;
+    const page = wrapper ? parseInt(wrapper.getAttribute("data-current-page") || "1", 10) : 1;
+    const pageSize = wrapper ? parseInt(wrapper.getAttribute("data-page-size") || "100", 10) : 100;
     if (
       tableName &&
       window.vscode &&
@@ -3756,7 +3755,7 @@ function handleTableDataDelta({
       return;
     }
     rowData.forEach((val, colIdx) => {
-      const cell = row.children[colIdx];
+      const cell = row.querySelector(`td[data-column="${colIdx}"]`);
       if (cell) {
         const cc = cell.querySelector(".cell-content");
         if (cc) {
@@ -3791,7 +3790,7 @@ function handleTableDataDelta({
         }
       });
       // Use renderTableRows to generate the new row HTML, but robustly patch FK cells after creation
-      let columns = Array.from(wrapper.querySelectorAll("thead th")).map((th) =>
+      let columns = Array.from(wrapper.querySelectorAll("thead th[data-column-name]")).map((th) =>
         th.getAttribute("data-column-name"),
       );
       // Fallback: if any column name is missing, try to get from global schema (handle window typing)
@@ -3984,6 +3983,7 @@ function handleTableDataDelta({
       new Error().stack,
     );
   }
+  clearSelection(wrapper);
 }
 
 // Remove all export statements for browser compatibility

--- a/media/resizing.js
+++ b/media/resizing.js
@@ -499,10 +499,11 @@ function initializeTableLayout(tableWrapper) {
   }
 
   // Set initial column widths based on content
-  const headers = table.querySelectorAll("th");
-  headers.forEach((header, index) => {
-    // Get the maximum content width for this column
-    const columnCells = table.querySelectorAll(`td[data-column="${index}"]`);
+  const headers = table.querySelectorAll("th[data-column]");
+  headers.forEach((header) => {
+    const colIdx = header.getAttribute("data-column");
+    if (colIdx === null) return;
+    const columnCells = table.querySelectorAll(`td[data-column="${colIdx}"]`);
     let maxWidth = header.offsetWidth;
 
     columnCells.forEach((cell) => {

--- a/media/table.js
+++ b/media/table.js
@@ -504,7 +504,9 @@ function createDataTable(data, columns, tableName = "", options = {}) {
                 .join("")}
             </select>
           </div>
-          <button class="table-action-btn" title="Export visible data" data-action="export">💾 Export</button>`
+          <button class="table-action-btn" title="Export visible data" data-action="export">💾 Export</button>
+          <button class="table-action-btn table-action-btn-selection" title="Export selected rows" data-action="export-selected" style="display:none">📤 Export Selected</button>
+          <button class="table-action-btn table-action-btn-selection table-action-btn-danger" title="Delete selected rows" data-action="delete-selected" style="display:none">🗑️ Delete Selected</button>`
               : ""
           }
         </div>
@@ -512,9 +514,10 @@ function createDataTable(data, columns, tableName = "", options = {}) {
       <div class="table-scroll-container">
         <table class="data-table resizable-table" id="${tableId}" role="table" aria-label="Database table data" style="width: ${Math.max(
     0,
-    DEFAULT_COLUMN_WIDTH * columns.length
+    32 + DEFAULT_COLUMN_WIDTH * columns.length
   )}px;">
           <colgroup>
+            <col class="checkbox-col" style="width: 32px; min-width: 32px; max-width: 32px;" />
             ${columns
               .map(
                 (col, index) =>
@@ -526,6 +529,9 @@ function createDataTable(data, columns, tableName = "", options = {}) {
           </colgroup>
           <thead>
             <tr role="row">
+              <th class="checkbox-th" role="columnheader">
+                <input type="checkbox" class="select-all-checkbox" title="Select / deselect all rows" />
+              </th>
               ${columns
                 .map((col, index) => {
                   let fkInfo = foreignKeyMap.get(col);
@@ -582,7 +588,7 @@ function createDataTable(data, columns, tableName = "", options = {}) {
           <tbody role="rowgroup" class="table-body">
             ${
               virtualize
-                ? `<tr class="virtual-loading" role="row"><td class="virtual-loading-cell" role="cell" colspan="${columns.length}">Rendering…</td></tr>`
+                ? `<tr class="virtual-loading" role="row"><td class="virtual-loading-cell" role="cell" colspan="${columns.length + 1}">Rendering…</td></tr>`
                 : renderTableRows(
                     pageData,
                     startIndex,
@@ -668,6 +674,9 @@ function renderTableRowHtml(
 ) {
   return `
         <tr data-row-index="${globalIndex}" data-local-index="${localIndex}" class="resizable-row" role="row">
+          <td class="checkbox-cell" data-column="-1" role="gridcell">
+            <input type="checkbox" class="row-select-checkbox" data-global-index="${globalIndex}" />
+          </td>
           ${
             Array.isArray(row)
               ? row
@@ -1204,7 +1213,7 @@ function virtualRender(vs, { force }) {
   }
 
   const tbody = vs.tbody;
-  const colCount = Array.isArray(vs.columns) ? vs.columns.length : 0;
+  const colCount = Array.isArray(vs.columns) ? vs.columns.length + 1 : 0;
   const totalRows = Array.isArray(vs.order) ? vs.order.length : 0;
   const pageRows = Array.isArray(vs.pageData) ? vs.pageData.length : 0;
   const hasSearch = !!(vs.searchTerm && String(vs.searchTerm).trim().length);
@@ -1308,6 +1317,11 @@ function virtualRender(vs, { force }) {
   syncPinnedColumnsForVirtual(vs);
   syncColumnWidthsForVirtual(vs);
   syncRowHeightsForVirtual(vs);
+
+  // Re-apply multi-row selection classes to visible rows.
+  if (typeof updateSelectedUI === "function") {
+    updateSelectedUI(vs.wrapper);
+  }
 }
 
 function findRowAtOffset(prefix, offset) {
@@ -1878,15 +1892,27 @@ function filterTableByColumn(table, columnIndex, filterValue) {
 /**
  * Export table data as CSV
  * @param {Element} tableWrapper - Table wrapper element
+ * @param {object} [options] - Export options
+ * @param {boolean} [options.onlySelected] - Export only selected rows
  */
-function exportTableData(tableWrapper) {
+function exportTableData(tableWrapper, options = {}) {
   const wrapper = normalizeEnhancedTableWrapper(tableWrapper) || tableWrapper;
+  const sel = options.onlySelected ? getSelectionStore(wrapper) : null;
+  const hasSelection = sel && sel.size > 0;
+
   /** @type {any} */ const vs = wrapper && wrapper.__virtualTableState;
   if (vs && vs.enabled === true) {
     const headers = Array.from(
       vs.table.querySelectorAll("th .column-name")
     ).map((th) => th.textContent);
-    const rowData = (vs.order || []).map((sourceIndex) => {
+    let order = vs.order || [];
+    if (hasSelection) {
+      order = order.filter((sourceIndex) => {
+        const globalIndex = vs.startIndex + sourceIndex;
+        return sel.has(globalIndex);
+      });
+    }
+    const rowData = order.map((sourceIndex) => {
       const row = vs.pageData[sourceIndex];
       return Array.isArray(row)
         ? row.map((val) =>
@@ -1911,9 +1937,22 @@ function exportTableData(tableWrapper) {
   }
 
   const table = wrapper.querySelector(".data-table");
-  const visibleRows = table.querySelectorAll(
-    'tbody tr:not([style*="display: none"]):not(.filter-empty-row):not(.virtual-spacer):not(.virtual-loading):not(.virtual-empty)'
+  let visibleRows = Array.from(
+    table.querySelectorAll(
+      'tbody tr:not([style*="display: none"]):not(.filter-empty-row):not(.virtual-spacer):not(.virtual-loading):not(.virtual-empty)'
+    )
   );
+
+  // Filter to selected rows if requested
+  if (hasSelection) {
+    visibleRows = visibleRows.filter((row) => {
+      const globalIndex = parseInt(
+        row.getAttribute("data-row-index") || "",
+        10
+      );
+      return Number.isFinite(globalIndex) && sel.has(globalIndex);
+    });
+  }
 
   // Get headers
   const headers = Array.from(table.querySelectorAll("th .column-name")).map(
@@ -2260,6 +2299,248 @@ function updatePaginationControls(tableWrapper, data, currentPage, pageSize) {
   }
 }
 
+/**
+ * Selection management functions for multi-row selection.
+ * Selection state is stored in-memory per table (clears on page change / search).
+ */
+
+function getSelectionStore(tableWrapper) {
+  const tableId =
+    tableWrapper.getAttribute("data-table-id") ||
+    tableWrapper.dataset.tableId ||
+    "";
+  if (!tableId) return null;
+  if (!window.__selectionStore || !(window.__selectionStore instanceof Map))
+    window.__selectionStore = new Map();
+  if (!window.__selectionStore.has(tableId))
+    window.__selectionStore.set(tableId, new Set());
+  return window.__selectionStore.get(tableId);
+}
+
+function toggleRowSelection(tableWrapper, globalIndex) {
+  const sel = getSelectionStore(tableWrapper);
+  if (!sel) return;
+  if (sel.has(globalIndex)) sel.delete(globalIndex);
+  else sel.add(globalIndex);
+  updateSelectedUI(tableWrapper);
+}
+
+function setRowSelection(tableWrapper, globalIndex, selected) {
+  const sel = getSelectionStore(tableWrapper);
+  if (!sel) return;
+  if (selected) sel.add(globalIndex);
+  else sel.delete(globalIndex);
+  updateSelectedUI(tableWrapper);
+}
+
+function clearSelection(tableWrapper) {
+  const sel = getSelectionStore(tableWrapper);
+  if (sel) sel.clear();
+  updateSelectedUI(tableWrapper);
+}
+
+function getVisibleRowGlobalIndices(tableWrapper) {
+  const vs = /** @type {any} */ (tableWrapper).__virtualTableState;
+  if (vs && vs.enabled === true && Array.isArray(vs.order)) {
+    return (vs.order || []).map(
+      (sourceIndex) => vs.startIndex + sourceIndex
+    );
+  }
+  const indices = [];
+  const table = tableWrapper.querySelector(".data-table");
+  if (table) {
+    table.querySelectorAll("tr.resizable-row").forEach((row) => {
+      const idx = parseInt(row.getAttribute("data-row-index") || "", 10);
+      if (Number.isFinite(idx)) indices.push(idx);
+    });
+  }
+  return indices;
+}
+
+function updateSelectedUI(tableWrapper) {
+  const sel = getSelectionStore(tableWrapper);
+  if (!sel) return;
+
+  const count = sel.size;
+
+  // Update row classes and checkbox states
+  const table = tableWrapper.querySelector(".data-table");
+  if (table) {
+    table.querySelectorAll("tr.resizable-row").forEach((row) => {
+      const idx = parseInt(row.getAttribute("data-row-index") || "", 10);
+      if (Number.isFinite(idx)) {
+        const isSelected = sel.has(idx);
+        row.classList.toggle("selected", isSelected);
+        const cb = row.querySelector(".row-select-checkbox");
+        if (cb) cb.checked = isSelected;
+      }
+    });
+  }
+
+  // Update select-all checkbox state
+  const selectAllCb = tableWrapper.querySelector(".select-all-checkbox");
+  const visibleRows = table
+    ? table.querySelectorAll("tr.resizable-row")
+    : [];
+  if (selectAllCb && visibleRows.length > 0) {
+    const checkedCount = Array.from(visibleRows).filter((row) => {
+      const idx = parseInt(row.getAttribute("data-row-index") || "", 10);
+      return Number.isFinite(idx) && sel.has(idx);
+    }).length;
+    selectAllCb.checked = checkedCount === visibleRows.length;
+    selectAllCb.indeterminate =
+      checkedCount > 0 && checkedCount < visibleRows.length;
+  } else if (selectAllCb) {
+    selectAllCb.checked = false;
+    selectAllCb.indeterminate = false;
+  }
+
+  // Update footer info
+  const selectedInfo = tableWrapper.querySelector(".selected-info");
+  if (selectedInfo) {
+    selectedInfo.textContent = count > 0 ? `${count} selected` : "";
+  }
+
+  // Show/hide batch action buttons
+  const exportSelectedBtn = tableWrapper.querySelector(
+    '[data-action="export-selected"]'
+  );
+  const deleteSelectedBtn = tableWrapper.querySelector(
+    '[data-action="delete-selected"]'
+  );
+  if (exportSelectedBtn)
+    exportSelectedBtn.style.display = count > 0 ? "inline-flex" : "none";
+  if (deleteSelectedBtn)
+    deleteSelectedBtn.style.display = count > 0 ? "inline-flex" : "none";
+}
+
+/**
+ * Collect row identities for all currently-selected rows.
+ * Returns an array suitable for passing as rowId in a deleteRow message.
+ */
+function getSelectedRowIdentities(tableWrapper) {
+  const sel = getSelectionStore(tableWrapper);
+  if (!sel || sel.size === 0) return [];
+
+  const tableId =
+    tableWrapper.getAttribute("data-table-id") ||
+    tableWrapper.dataset.tableId ||
+    "";
+  const stash =
+    window.__tableDataStash instanceof Map
+      ? window.__tableDataStash.get(tableId)
+      : null;
+  const vs = /** @type {any} */ (tableWrapper).__virtualTableState;
+
+  if (stash && Array.isArray(stash.rowIdentities)) {
+    const startIndex = parseInt(
+      tableWrapper.getAttribute("data-start-index") || "0",
+      10
+    );
+    if (vs && vs.enabled === true) {
+      return (vs.order || [])
+        .map((sourceIndex) => vs.startIndex + sourceIndex)
+        .filter((g) => sel.has(g))
+        .map((g) => {
+          const li = g - vs.startIndex;
+          return stash.rowIdentities[li];
+        })
+        .filter(Boolean);
+    }
+    const identities = [];
+    const table = tableWrapper.querySelector(".data-table");
+    if (table) {
+      table.querySelectorAll("tr.resizable-row").forEach((row) => {
+        const idx = parseInt(row.getAttribute("data-row-index") || "", 10);
+        if (Number.isFinite(idx) && sel.has(idx)) {
+          const localIndex = idx - startIndex;
+          if (
+            localIndex >= 0 &&
+            localIndex < stash.rowIdentities.length
+          ) {
+            identities.push(stash.rowIdentities[localIndex]);
+          }
+        }
+      });
+    }
+    return identities.filter(Boolean);
+  }
+
+  return [];
+}
+
+/**
+ * Convert a RowIdentity (from the data stash) into the simple {column, value}
+ * or {col1: val1, ...} format expected by the backend delete handler.
+ */
+function rowIdentityToSimple(identity) {
+  if (identity && identity.kind && Array.isArray(identity.parts)) {
+    if (identity.parts.length === 1) {
+      return {
+        column: identity.parts[0].column,
+        value: identity.parts[0].value,
+      };
+    }
+    const obj = {};
+    identity.parts.forEach((p) => {
+      obj[p.column] = p.value;
+    });
+    return obj;
+  }
+  return identity;
+}
+
+/**
+ * Confirm and delete all selected rows.
+ */
+function deleteSelectedRows(tableWrapper) {
+  const sel = getSelectionStore(tableWrapper);
+  if (!sel || sel.size === 0) return;
+
+  const count = sel.size;
+  const tableName =
+    tableWrapper.getAttribute("data-table") || tableWrapper.dataset.table || "";
+  if (!tableName) return;
+
+  const identities = getSelectedRowIdentities(tableWrapper);
+  if (identities.length === 0) {
+    if (typeof showError === "function")
+      showError("Could not identify selected rows. Refresh the table and try again.");
+    return;
+  }
+
+  const doDelete = () => {
+    if (typeof showDeleteLoading === "function") showDeleteLoading();
+    const state =
+      typeof getCurrentState === "function" ? getCurrentState() : {};
+    const encryptionKey = state.encryptionKey || "";
+    if (
+      window.vscode &&
+      typeof window.vscode.postMessage === "function"
+    ) {
+      window.vscode.postMessage({
+        type: "deleteRow",
+        tableName: tableName,
+        rowId: identities.map(rowIdentityToSimple),
+        key: encryptionKey,
+      });
+    } else if (typeof showDeleteError === "function") {
+      showDeleteError("Cannot communicate with extension");
+    }
+  };
+
+  if (typeof showEnhancedConfirmDialog === "function") {
+    showEnhancedConfirmDialog(
+      `Delete ${count} selected row${count !== 1 ? "s" : ""}?`,
+      doDelete,
+      tableName,
+      null
+    );
+  } else {
+    doDelete();
+  }
+}
+
 // Make functions available globally for cross-module access
 if (typeof window !== "undefined") {
   /** @type {any} */ (window).createDataTable = createDataTable;
@@ -2284,6 +2565,13 @@ if (typeof window !== "undefined") {
     updateRowMultilineForRow;
   /** @type {any} */ (window).updateRowMultilineForTable =
     updateRowMultilineForTable;
+  /** @type {any} */ (window).getSelectionStore = getSelectionStore;
+  /** @type {any} */ (window).toggleRowSelection = toggleRowSelection;
+  /** @type {any} */ (window).setRowSelection = setRowSelection;
+  /** @type {any} */ (window).clearSelection = clearSelection;
+  /** @type {any} */ (window).updateSelectedUI = updateSelectedUI;
+  /** @type {any} */ (window).getSelectedRowIdentities = getSelectedRowIdentities;
+  /** @type {any} */ (window).deleteSelectedRows = deleteSelectedRows;
   /** @type {any} */ (window).TABLE_ROW_HEIGHT_DEFAULT = DEFAULT_ROW_HEIGHT;
   /** @type {any} */ (window).TABLE_ROW_HEIGHT_MULTILINE = MULTILINE_ROW_HEIGHT;
   /** @type {any} */ (window).TABLE_CELL_LINE_HEIGHT = CELL_LINE_HEIGHT;

--- a/media/table.js
+++ b/media/table.js
@@ -456,7 +456,7 @@ function createDataTable(data, columns, tableName = "", options = {}) {
     backendPaginated ? "true" : "false"
   }" data-virtualized="${
     virtualize ? "true" : "false"
-  }" data-total-rows-known="${totalRowsKnown ? "true" : "false"}">
+  }" data-total-rows-known="${totalRowsKnown ? "true" : "false"}" data-editable="${isEditable}">
       <div class="table-controls">
         <div class="table-search">
           <input type="text" class="search-input" placeholder="Search table page..." />
@@ -505,8 +505,8 @@ function createDataTable(data, columns, tableName = "", options = {}) {
             </select>
           </div>
           <button class="table-action-btn" title="Export visible data" data-action="export">💾 Export</button>
-          <button class="table-action-btn table-action-btn-selection" title="Export selected rows" data-action="export-selected" style="display:none">📤 Export Selected</button>
-          <button class="table-action-btn table-action-btn-selection table-action-btn-danger" title="Delete selected rows" data-action="delete-selected" style="display:none">🗑️ Delete Selected</button>`
+          <button class="table-action-btn table-action-btn-selection" title="Export selected rows" data-action="export-selected">📤 Export Selected</button>
+          ${isEditable ? '<button class="table-action-btn table-action-btn-selection table-action-btn-danger" title="Delete selected rows" data-action="delete-selected">🗑️ Delete Selected</button>' : ""}`
               : ""
           }
         </div>
@@ -517,7 +517,7 @@ function createDataTable(data, columns, tableName = "", options = {}) {
     32 + DEFAULT_COLUMN_WIDTH * columns.length
   )}px;">
           <colgroup>
-            <col class="checkbox-col" style="width: 32px; min-width: 32px; max-width: 32px;" />
+            <col class="checkbox-col" />
             ${columns
               .map(
                 (col, index) =>
@@ -675,7 +675,7 @@ function renderTableRowHtml(
   return `
         <tr data-row-index="${globalIndex}" data-local-index="${localIndex}" class="resizable-row" role="row">
           <td class="checkbox-cell" data-column="-1" role="gridcell">
-            <input type="checkbox" class="row-select-checkbox" data-global-index="${globalIndex}" />
+            <input type="checkbox" class="row-select-checkbox" data-global-index="${globalIndex}" aria-label="Select row ${globalIndex + 1}" />
           </td>
           ${
             Array.isArray(row)
@@ -1961,7 +1961,9 @@ function exportTableData(tableWrapper, options = {}) {
 
   // Get visible row data
   const rowData = Array.from(visibleRows).map((row) => {
-    return Array.from(row.querySelectorAll("td")).map((td) => {
+    return Array.from(row.querySelectorAll("td[data-column]"))
+      .filter((td) => parseInt(td.getAttribute("data-column") || "-1", 10) >= 0)
+      .map((td) => {
       let value = getCellValue ? getCellValue(td) : td.textContent.trim();
       return value === "NULL" ? "" : value;
     });
@@ -2339,6 +2341,13 @@ function clearSelection(tableWrapper) {
   updateSelectedUI(tableWrapper);
 }
 
+/**
+ * Return the global indices of all visible (non-filtered, non-hidden) rows.
+ * For virtualised tables uses the ordered source index; for non-virtualised
+ * excludes rows with display:none.
+ * @param {HTMLElement} tableWrapper - The .enhanced-table-wrapper element
+ * @returns {number[]} Visible global row indices
+ */
 function getVisibleRowGlobalIndices(tableWrapper) {
   const vs = /** @type {any} */ (tableWrapper).__virtualTableState;
   if (vs && vs.enabled === true && Array.isArray(vs.order)) {
@@ -2349,7 +2358,7 @@ function getVisibleRowGlobalIndices(tableWrapper) {
   const indices = [];
   const table = tableWrapper.querySelector(".data-table");
   if (table) {
-    table.querySelectorAll("tr.resizable-row").forEach((row) => {
+    table.querySelectorAll("tr.resizable-row:not([style*='display: none'])").forEach((row) => {
       const idx = parseInt(row.getAttribute("data-row-index") || "", 10);
       if (Number.isFinite(idx)) indices.push(idx);
     });
@@ -2357,6 +2366,11 @@ function getVisibleRowGlobalIndices(tableWrapper) {
   return indices;
 }
 
+/**
+ * Synchronise row checkbox states, selected-row classes, and action-button visibility
+ * with the current selection store state.
+ * @param {HTMLElement} tableWrapper - The .enhanced-table-wrapper element
+ */
 function updateSelectedUI(tableWrapper) {
   const sel = getSelectionStore(tableWrapper);
   if (!sel) return;
@@ -2366,7 +2380,7 @@ function updateSelectedUI(tableWrapper) {
   // Update row classes and checkbox states
   const table = tableWrapper.querySelector(".data-table");
   if (table) {
-    table.querySelectorAll("tr.resizable-row").forEach((row) => {
+    table.querySelectorAll("tr.resizable-row:not([style*='display: none'])").forEach((row) => {
       const idx = parseInt(row.getAttribute("data-row-index") || "", 10);
       if (Number.isFinite(idx)) {
         const isSelected = sel.has(idx);
@@ -2380,7 +2394,7 @@ function updateSelectedUI(tableWrapper) {
   // Update select-all checkbox state
   const selectAllCb = tableWrapper.querySelector(".select-all-checkbox");
   const visibleRows = table
-    ? table.querySelectorAll("tr.resizable-row")
+    ? table.querySelectorAll("tr.resizable-row:not([style*='display: none'])")
     : [];
   if (selectAllCb && visibleRows.length > 0) {
     const checkedCount = Array.from(visibleRows).filter((row) => {
@@ -2409,9 +2423,9 @@ function updateSelectedUI(tableWrapper) {
     '[data-action="delete-selected"]'
   );
   if (exportSelectedBtn)
-    exportSelectedBtn.style.display = count > 0 ? "inline-flex" : "none";
+    exportSelectedBtn.classList.toggle("hidden", count === 0);
   if (deleteSelectedBtn)
-    deleteSelectedBtn.style.display = count > 0 ? "inline-flex" : "none";
+    deleteSelectedBtn.classList.toggle("hidden", count === 0);
 }
 
 /**
@@ -2493,9 +2507,16 @@ function rowIdentityToSimple(identity) {
 /**
  * Confirm and delete all selected rows.
  */
+/**
+ * Confirm and delete all selected rows.
+ * Checks editability via data-editable attribute before proceeding.
+ * @param {HTMLElement} tableWrapper - The .enhanced-table-wrapper element
+ */
 function deleteSelectedRows(tableWrapper) {
+  if (tableWrapper.dataset.editable !== "true") return;
   const sel = getSelectionStore(tableWrapper);
   if (!sel || sel.size === 0) return;
+
 
   const count = sel.size;
   const tableName =

--- a/media/table.js
+++ b/media/table.js
@@ -2517,6 +2517,14 @@ function deleteSelectedRows(tableWrapper) {
   const sel = getSelectionStore(tableWrapper);
   if (!sel || sel.size === 0) return;
 
+  // Safety: ensure the stash has identity data (may be stale after delta)
+  const tableId = tableWrapper.getAttribute("data-table-id") || tableWrapper.dataset.tableId || "";
+  const stashData = window.__tableDataStash instanceof Map ? window.__tableDataStash.get(tableId) : null;
+  if (!stashData || !Array.isArray(stashData.rowIdentities) || stashData.rowIdentities.length === 0) {
+    if (typeof showError === "function")
+      showError("Selection data unavailable. Refresh the table and try again.");
+    return;
+  }
 
   const count = sel.size;
   const tableName =

--- a/media/tests/TESTS.md
+++ b/media/tests/TESTS.md
@@ -6,7 +6,7 @@ Tests for `media/table.js` (and `media/utils.js`) are in the `tests/` directory.
 
 Install dependencies and run with vitest:
 
-```
+```bash
 npm install --save-dev vitest jsdom
 npm run test-media
 ```

--- a/media/tests/TESTS.md
+++ b/media/tests/TESTS.md
@@ -1,0 +1,30 @@
+# Table Tests
+
+Tests for `media/table.js` (and `media/utils.js`) are in the `tests/` directory.
+
+## Running
+
+Install dependencies and run with vitest:
+
+```
+npm install --save-dev vitest jsdom
+npm run test-media
+```
+
+The `test-media` script should be added to `package.json`:
+
+```json
+"test-media": "vitest run"
+```
+
+Vitest config at project root (`vitest.config.js`):
+
+```js
+import {defineConfig} from 'vitest/config'
+export default defineConfig({ test: { environment: 'jsdom', include: ['media/tests/**/*.test.js'] } });
+```
+
+## Files
+
+- `table.test.js` — 12 tests covering fixes #3–#7, #10
+- `helpers.js` — DOM/fixture utilities shared by tests

--- a/media/tests/TESTS.md
+++ b/media/tests/TESTS.md
@@ -6,10 +6,6 @@ Tests for `media/table.js` (and `media/utils.js`) are in the `tests/` directory.
 
 Install dependencies and run with vitest:
 
-```
-npm install --save-dev vitest jsdom
-npm run test-media
-```
 
 The `test-media` script should be added to `package.json`:
 

--- a/media/tests/table.test.js
+++ b/media/tests/table.test.js
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import fs from 'fs';
+import { JSDOM } from 'jsdom';
+
+beforeAll(() => {
+  const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>');
+  global.window = dom.window;
+  global.document = dom.window.document;
+
+  const utilsCode = fs.readFileSync('media/utils.js', 'utf-8');
+  const tableCode = fs.readFileSync('media/table.js', 'utf-8');
+
+  const wrapperCode = `
+    ${utilsCode}
+    ${tableCode}
+    window.getVisibleRowGlobalIndices = getVisibleRowGlobalIndices;
+  `;
+
+  new Function('window', 'document', wrapperCode)(window, document);
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+//test for issue 7
+it('getVisibleRowGlobalIndices skips hidden rows', () => {
+  document.body.innerHTML = `
+    <div class="enhanced-table-wrapper" data-table-id="t1" data-start-index="0">
+      <table class="data-table"><tbody>
+        <tr class="resizable-row" data-row-index="0"><td>A</td></tr>
+        <tr class="resizable-row" data-row-index="1" style="display: none"><td>B</td></tr>
+        <tr class="resizable-row" data-row-index="2"><td>C</td></tr>
+      </tbody></table></div>`;
+
+  const wrapper = document.querySelector('.enhanced-table-wrapper');
+  
+  expect(window.getVisibleRowGlobalIndices(wrapper)).toEqual([0, 2]);
+});
+
+describe('Fix #3 — isEditable gate', () => {
+  it('sets data-editable on rendered wrapper', () => {
+    const html = window.createDataTable([['val']], ['col'], 'test', {
+      page: 1, pageSize: 100, allowEditing: true
+    });
+    const div = document.createElement('div');
+    div.innerHTML = html;
+    const wrapper = div.querySelector('.enhanced-table-wrapper');
+    expect(wrapper.getAttribute('data-editable')).toBe('true');
+  });
+
+  it('sets data-editable="false" for query results', () => {
+    const html = window.createDataTable([['val']], ['col'], 'test', {
+      page: 1, pageSize: 100, isQueryResult: true
+    });
+    const div = document.createElement('div');
+    div.innerHTML = html;
+    const wrapper = div.querySelector('.enhanced-table-wrapper');
+    expect(wrapper.getAttribute('data-editable')).toBe('false');
+  });
+
+  it('deleteSelectedRows returns early when not editable', () => {
+    const wrapper = document.createElement('div');
+    wrapper.setAttribute('data-table-id', 't1');
+    wrapper.dataset.editable = 'false';
+    expect(() => window.deleteSelectedRows(wrapper)).not.toThrow();
+  });
+});
+
+describe('Fix #5 — checkbox aria-label', () => {
+  it('uses row number in aria-label', () => {
+    const html = window.createDataTable(
+      [['Alice'], ['Bob']], ['name'], 'test', {
+        page: 1, pageSize: 100, allowEditing: false
+      }
+    );
+    const div = document.createElement('div');
+    div.innerHTML = html;
+    const checkboxes = div.querySelectorAll('.row-select-checkbox');
+    expect(checkboxes.length).toBe(2);
+    expect(checkboxes[0].getAttribute('aria-label')).toBe('Select row 1');
+    expect(checkboxes[1].getAttribute('aria-label')).toBe('Select row 2');
+  });
+});
+
+describe('Fix #4 — no inline display:none on buttons', () => {
+  it('uses CSS classes instead of inline display', () => {
+    const html = window.createDataTable([['val']], ['col'], 'test', {
+      page: 1, pageSize: 100, allowEditing: true
+    });
+    const div = document.createElement('div');
+    div.innerHTML = html;
+    const exportBtn = div.querySelector('[data-action="export-selected"]');
+    const deleteBtn = div.querySelector('[data-action="delete-selected"]');
+    expect(exportBtn).toBeTruthy();
+    expect(deleteBtn).toBeTruthy();
+    expect(exportBtn.style.display).not.toBe('none');
+    expect(deleteBtn.style.display).not.toBe('none');
+  });
+
+  it('hides delete button when table is not editable', () => {
+    const html = window.createDataTable([['val']], ['col'], 'test', {
+      page: 1, pageSize: 100, allowEditing: false
+    });
+    const div = document.createElement('div');
+    div.innerHTML = html;
+    const deleteBtn = div.querySelector('[data-action="delete-selected"]');
+    expect(deleteBtn).toBeNull();
+  });
+});
+
+describe('Fix #6 — clearSelection on delta', () => {
+  it('clears selection after rows are toggled', () => {
+    const wrapper = document.createElement('div');
+    wrapper.setAttribute('data-table-id', 't1');
+
+    window.toggleRowSelection(wrapper, 5);
+    window.toggleRowSelection(wrapper, 10);
+    const store = window.getSelectionStore(wrapper);
+    expect(store.size).toBe(2);
+
+    window.clearSelection(wrapper);
+    expect(store.size).toBe(0);
+  });
+
+  it('does not throw when no selection store exists', () => {
+    const wrapper = document.createElement('div');
+    // no data-table-id, so no store
+    expect(() => window.clearSelection(wrapper)).not.toThrow();
+  });
+
+  it('handles multiple clearSelection calls safely', () => {
+    const wrapper = document.createElement('div');
+    wrapper.setAttribute('data-table-id', 't2');
+
+    window.toggleRowSelection(wrapper, 3);
+    window.clearSelection(wrapper);
+    window.clearSelection(wrapper); // second call
+    const store = window.getSelectionStore(wrapper);
+    expect(store.size).toBe(0);
+  });
+
+  it('getSelectedRowIdentities returns empty after clear', () => {
+    const wrapper = document.createElement('div');
+    wrapper.setAttribute('data-table-id', 't3');
+    wrapper.setAttribute('data-start-index', '0');
+
+    window.toggleRowSelection(wrapper, 0);
+    expect(window.getSelectedRowIdentities(wrapper)).toEqual([]);
+  });
+});
+
+describe('Fix #10 — export excludes checkbox column', () => {
+  it('skips checkbox td[data-column="-1"] from export data', () => {
+    const html = window.createDataTable([['a', 'b']], ['c1', 'c2'], 'test', {
+      page: 1, pageSize: 100, allowEditing: false
+    });
+    document.body.innerHTML = html;
+    const wrapper = document.querySelector('.enhanced-table-wrapper');
+    const table = wrapper.querySelector('.data-table');
+    const row = table.querySelector('tbody tr');
+    const cells = row.querySelectorAll('td');
+    // First cell should be checkbox (data-column="-1")
+    expect(cells[0].getAttribute('data-column')).toBe('-1');
+    expect(cells[0].classList.contains('checkbox-cell')).toBe(true);
+    // Data cells should have non-negative data-column
+    expect(cells[1].getAttribute('data-column')).toBe('0');
+    expect(cells[2].getAttribute('data-column')).toBe('1');
+  });
+});

--- a/media/tests/table.test.js
+++ b/media/tests/table.test.js
@@ -146,6 +146,8 @@ describe('Fix #6 — clearSelection on delta', () => {
     wrapper.setAttribute('data-start-index', '0');
 
     window.toggleRowSelection(wrapper, 0);
+    expect(window.getSelectionStore(wrapper).size).toBe(1);
+    window.clearSelection(wrapper);
     expect(window.getSelectedRowIdentities(wrapper)).toEqual([]);
   });
 });

--- a/media/tests/table.test.js
+++ b/media/tests/table.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest';
 import fs from 'fs';
 import { JSDOM } from 'jsdom';
 
@@ -166,5 +166,133 @@ describe('Fix #10 — export excludes checkbox column', () => {
     // Data cells should have non-negative data-column
     expect(cells[1].getAttribute('data-column')).toBe('0');
     expect(cells[2].getAttribute('data-column')).toBe('1');
+  });
+});
+
+describe('Stale identity fix — delta splices stash.rowIdentities', () => {
+  beforeEach(() => {
+    if (!window.__tableDataStash || !(window.__tableDataStash instanceof Map)) {
+      window.__tableDataStash = new Map();
+    }
+  });
+
+  it('getSelectedRowIdentities returns correct identity after delta-like stash splice', () => {
+    const wrapper = document.createElement('div');
+    wrapper.setAttribute('data-table-id', 'stale-dom');
+    wrapper.setAttribute('data-start-index', '0');
+    wrapper.innerHTML = `
+      <table class="data-table"><tbody>
+        <tr class="resizable-row" data-row-index="0"><td>A</td></tr>
+        <tr class="resizable-row" data-row-index="1"><td>B</td></tr>
+        <tr class="resizable-row" data-row-index="2"><td>C</td></tr>
+        <tr class="resizable-row" data-row-index="3"><td>D</td></tr>
+      </tbody></table>`;
+
+    // Stash row identities matching the 4 rows
+    window.__tableDataStash.set('stale-dom', {
+      rowIdentities: [
+        { kind: 'primaryKey', parts: [{ column: 'id', value: 1 }] },
+        { kind: 'primaryKey', parts: [{ column: 'id', value: 2 }] },
+        { kind: 'primaryKey', parts: [{ column: 'id', value: 3 }] },
+        { kind: 'primaryKey', parts: [{ column: 'id', value: 4 }] },
+      ]
+    });
+
+    // Select row C (globalIndex=2)
+    window.toggleRowSelection(wrapper, 2);
+    expect(window.getSelectedRowIdentities(wrapper)).toEqual([
+      { kind: 'primaryKey', parts: [{ column: 'id', value: 3 }] }
+    ]);
+
+    // Simulate delta delete of row B (index 1), mirroring what handleTableDataDelta does:
+    // 1. Remove B's DOM row
+    const bRow = wrapper.querySelector('tr[data-row-index="1"]');
+    bRow.remove();
+    // 2. Decrement data-row-index for rows after the deletion point
+    wrapper.querySelectorAll('tr.resizable-row').forEach(r => {
+      const idx = parseInt(r.getAttribute('data-row-index'), 10);
+      if (Number.isFinite(idx) && idx > 1) {
+        r.setAttribute('data-row-index', String(idx - 1));
+      }
+    });
+    // 3. Splice stash rowIdentities at the same local index
+    window.__tableDataStash.get('stale-dom').rowIdentities.splice(1, 1);
+    // 4. Clear selection (DOM path safety net)
+    window.clearSelection(wrapper);
+
+    // Now rows are: A(0), C(1), D(2)
+    // Selection was cleared — re-select C at its new position (globalIndex=1)
+    window.toggleRowSelection(wrapper, 1);
+    const ids = window.getSelectedRowIdentities(wrapper);
+    // Must return C's identity (value 3), not D's (value 4)
+    expect(ids).toEqual([
+      { kind: 'primaryKey', parts: [{ column: 'id', value: 3 }] }
+    ]);
+  });
+
+  it('virtual path: splice stash at correct indices for multiple deletes', () => {
+    const wrapper = document.createElement('div');
+    wrapper.setAttribute('data-table-id', 'stale-virt');
+    wrapper.setAttribute('data-start-index', '0');
+    wrapper.innerHTML = `
+      <table class="data-table"><tbody>
+        <tr class="resizable-row" data-row-index="0"><td>A</td></tr>
+        <tr class="resizable-row" data-row-index="1"><td>B</td></tr>
+        <tr class="resizable-row" data-row-index="2"><td>C</td></tr>
+        <tr class="resizable-row" data-row-index="3"><td>D</td></tr>
+      </tbody></table>`;
+    // Simulate virtual state so getSelectedRowIdentities takes the virtual path
+    wrapper.__virtualTableState = {
+      enabled: true,
+      startIndex: 0,
+      order: [0, 1, 2, 3],
+    };
+
+    window.__tableDataStash.set('stale-virt', {
+      rowIdentities: [
+        { kind: 'primaryKey', parts: [{ column: 'id', value: 1 }] },
+        { kind: 'primaryKey', parts: [{ column: 'id', value: 2 }] },
+        { kind: 'primaryKey', parts: [{ column: 'id', value: 3 }] },
+        { kind: 'primaryKey', parts: [{ column: 'id', value: 4 }] },
+      ]
+    });
+
+    // Select C (globalIndex=2)
+    window.toggleRowSelection(wrapper, 2);
+    expect(window.getSelectedRowIdentities(wrapper)).toEqual([
+      { kind: 'primaryKey', parts: [{ column: 'id', value: 3 }] }
+    ]);
+
+    // Simulate virtual path delta: splice pageData AND rowIdentities bottom-up
+    const stashIdentities = window.__tableDataStash.get('stale-virt').rowIdentities;
+    const deletes = [1, 3].sort((a, b) => b - a); // delete B and D
+    deletes.forEach(local => {
+      stashIdentities.splice(local, 1);
+    });
+    // Reconcile selection (simulating what Fix 3 does)
+    const sel = window.getSelectionStore(wrapper);
+    sel.delete(2); // globalIndex=2 is no longer valid since D was at 3
+    // D was at index 3, after deleting B, it shifted to 2, but D itself was also deleted
+    // C was at index 2, after deleting B(1), C shifted to 1, so globalIndex 2 is stale
+
+    // After reconcile, selection should be empty since C was at index 2
+    // which was a deleted row (D)'s position after B was removed
+    expect(window.getSelectedRowIdentities(wrapper)).toEqual([]);
+  });
+
+  it('deleteSelectedRows refuses when stash has no rowIdentities', () => {
+    const wrapper = document.createElement('div');
+    wrapper.setAttribute('data-table-id', 'stale-guard');
+    wrapper.setAttribute('data-table', 'test_table');
+    wrapper.dataset.editable = 'true';
+
+    window.__tableDataStash.set('stale-guard', {
+      // no rowIdentities array
+      columns: ['id', 'name'],
+    });
+
+    window.toggleRowSelection(wrapper, 0);
+    // Should not throw; should return early with an error
+    expect(() => window.deleteSelectedRows(wrapper)).not.toThrow();
   });
 });


### PR DESCRIPTION
- Add checkbox column (individual + select-all) for row selection
- Both row-click and checkbox toggle selection
- Batch 'Export Selected' and 'Delete Selected' buttons in action bar
- Expose selection functions on window for cross-file access
- Fix delete error: convert RowIdentity to simple {column,value} format expected by backend delete handler
- Fix context-menu.js nth-child and row.cells references for shifted columns
- Fix resizing.js th iteration to skip checkbox column via data-column attr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added multi-row selection with a checkbox column, including “select all”, batch action UI, and selection-aware export of only selected rows.
  - Extended export options and introduced per-table in-memory selection management for UI state and batch deletion.
  - Improved table visuals for selected rows, checkbox column layout, and action-button selection states.

- **Bug Fixes**
  - Improved column/cell targeting for copy, foreign-key highlighting, resizing, and table delta updates using column data attributes.
  - Corrected selection identity handling across pagination, virtualised updates, and multi-row deletes; selection is cleared on search and after updates.

- **Tests**
  - Expanded Vitest + JSDOM coverage, including stale-identity and early-return scenarios, plus added a test-run guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->